### PR TITLE
test(amplify_event_enrichment): add unit tests

### DIFF
--- a/.github/workflows/amplify_event_enrichment_dart.yaml
+++ b/.github/workflows/amplify_event_enrichment_dart.yaml
@@ -7,6 +7,7 @@ on:
       - stable
     paths:
       - '.github/workflows/amplify_event_enrichment_dart.yaml'
+      - '.github/workflows/dart_native.yaml'
       - '.github/workflows/dart_vm.yaml'
       - 'packages/amplify_event_enrichment/amplify_event_enrichment_dart/**/*.dart'
       - 'packages/amplify_event_enrichment/amplify_event_enrichment_dart/**/*.yaml'
@@ -19,6 +20,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/amplify_event_enrichment_dart.yaml'
+      - '.github/workflows/dart_native.yaml'
       - '.github/workflows/dart_vm.yaml'
       - 'packages/amplify_event_enrichment/amplify_event_enrichment_dart/**/*.dart'
       - 'packages/amplify_event_enrichment/amplify_event_enrichment_dart/**/*.yaml'
@@ -50,6 +52,13 @@ jobs:
   test:
     uses: ./.github/workflows/dart_vm.yaml
     secrets: inherit
+    with:
+      package-name: amplify_event_enrichment_dart
+      working-directory: packages/amplify_event_enrichment/amplify_event_enrichment_dart
+  native_test:
+    needs: test
+    uses: ./.github/workflows/dart_native.yaml
+    secrets: inherit 
     with:
       package-name: amplify_event_enrichment_dart
       working-directory: packages/amplify_event_enrichment/amplify_event_enrichment_dart

--- a/.github/workflows/amplify_event_enrichment_dart.yaml
+++ b/.github/workflows/amplify_event_enrichment_dart.yaml
@@ -72,3 +72,17 @@ jobs:
     with:
       package-name: amplify_event_enrichment_dart
       working-directory: packages/amplify_event_enrichment/amplify_event_enrichment_dart
+  ddc_test:
+    needs: test
+    uses: ./.github/workflows/dart_ddc.yaml
+    secrets: inherit
+    with:
+      package-name: amplify_event_enrichment_dart
+      working-directory: packages/amplify_event_enrichment/amplify_event_enrichment_dart
+  dart2js_test:
+    needs: test
+    uses: ./.github/workflows/dart_dart2js.yaml
+    secrets: inherit
+    with:
+      package-name: amplify_event_enrichment_dart
+      working-directory: packages/amplify_event_enrichment/amplify_event_enrichment_dart

--- a/.github/workflows/amplify_event_enrichment_dart.yaml
+++ b/.github/workflows/amplify_event_enrichment_dart.yaml
@@ -10,6 +10,7 @@ on:
       - '.github/workflows/amplify_event_enrichment_dart.yaml'
       - '.github/workflows/dart_dart2js.yaml'
       - '.github/workflows/dart_ddc.yaml'
+      - '.github/workflows/dart_native.yaml'
       - '.github/workflows/dart_vm.yaml'
       - 'packages/amplify_event_enrichment/amplify_event_enrichment_dart/**/*.dart'
       - 'packages/amplify_event_enrichment/amplify_event_enrichment_dart/**/*.yaml'
@@ -27,6 +28,7 @@ on:
       - '.github/workflows/amplify_event_enrichment_dart.yaml'
       - '.github/workflows/dart_dart2js.yaml'
       - '.github/workflows/dart_ddc.yaml'
+      - '.github/workflows/dart_native.yaml'
       - '.github/workflows/dart_vm.yaml'
       - 'packages/amplify_event_enrichment/amplify_event_enrichment_dart/**/*.dart'
       - 'packages/amplify_event_enrichment/amplify_event_enrichment_dart/**/*.yaml'
@@ -60,6 +62,13 @@ jobs:
   test:
     uses: ./.github/workflows/dart_vm.yaml
     secrets: inherit
+    with:
+      package-name: amplify_event_enrichment_dart
+      working-directory: packages/amplify_event_enrichment/amplify_event_enrichment_dart
+  native_test:
+    needs: test
+    uses: ./.github/workflows/dart_native.yaml
+    secrets: inherit 
     with:
       package-name: amplify_event_enrichment_dart
       working-directory: packages/amplify_event_enrichment/amplify_event_enrichment_dart

--- a/packages/amplify_event_enrichment/amplify_event_enrichment/test/event_enrichment_client_flutter_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment/test/event_enrichment_client_flutter_test.dart
@@ -1,0 +1,40 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_event_enrichment/amplify_event_enrichment.dart';
+import 'package:amplify_foundation_dart/amplify_foundation_dart.dart' show Ok;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _ThrowingDeviceMetadataProvider implements DeviceMetadataProvider {
+  @override
+  Future<DeviceMetadata> getDeviceMetadata() async =>
+      throw StateError('provider failure');
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  group('EventEnrichmentClientFlutter.create', () {
+    test('degrades gracefully when device metadata resolution fails', () async {
+      // create() must not throw when a provider fails; it falls back to empty
+      // device metadata and the client stays usable.
+      final client = await EventEnrichmentClientFlutter.create(
+        appId: 'test-app',
+        sdkMetadata: const SdkMetadata(
+          name: 'amplify-flutter',
+          version: '2.0.0',
+        ),
+        deviceMetadataProvider: _ThrowingDeviceMetadataProvider(),
+      );
+      addTearDown(client.close);
+
+      final result = client.record('event');
+      expect(result, isA<Ok<EnrichedEvent>>());
+    });
+  });
+}

--- a/packages/amplify_event_enrichment/amplify_event_enrichment/test/event_enrichment_client_flutter_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment/test/event_enrichment_client_flutter_test.dart
@@ -26,6 +26,18 @@ class _ThrowingClientIdProvider implements ClientIdProvider {
   Future<String> getClientId() async => throw StateError('provider failure');
 }
 
+class _RecordingSender implements Sender {
+  final List<EnrichedEvent> events = [];
+
+  @override
+  Future<void> send(EnrichedEvent event) async => events.add(event);
+
+  /// Only the session-stop events, so counts are unaffected by whatever the
+  /// test recorded to get a session started.
+  List<EnrichedEvent> get sessionStops =>
+      events.where((e) => e.eventType == zSessionStopEventType).toList();
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -98,7 +110,7 @@ void main() {
       addTearDown(client.close);
 
       final first = (await client.record('first') as Ok<EnrichedEvent>).value;
-      client.stopSession();
+      await client.stopSession();
       final second = (await client.record('second') as Ok<EnrichedEvent>).value;
 
       expect(second.session.id, isNot(first.session.id));
@@ -113,7 +125,7 @@ void main() {
       addTearDown(client.close);
 
       final first = (await client.record('first') as Ok<EnrichedEvent>).value;
-      client.startSession();
+      await client.startSession();
       final second = (await client.record('second') as Ok<EnrichedEvent>).value;
 
       expect(second.session.id, isNot(first.session.id));
@@ -145,8 +157,8 @@ void main() {
         addTearDown(client.close);
 
         final first = (await client.record('first') as Ok<EnrichedEvent>).value;
+        await client.stopSession();
         client
-          ..stopSession()
           ..handleAppPaused()
           ..handleAppResumed();
 
@@ -173,6 +185,77 @@ void main() {
 
       final event = (await client.record('event') as Ok<EnrichedEvent>).value;
       expect(event.session.id, isNotEmpty);
+    });
+  });
+
+  group('EventEnrichmentClientFlutter session stop events', () {
+    Future<(EventEnrichmentClientFlutter, _RecordingSender)> createClient({
+      bool autoSessionTracking = true,
+    }) async {
+      final sender = _RecordingSender();
+      final client = await EventEnrichmentClientFlutter.create(
+        appId: 'test-app',
+        sdkMetadata: sdk,
+        sender: sender,
+        options: EventEnrichmentClientOptions(
+          autoSessionTracking: autoSessionTracking,
+        ),
+      );
+      return (client, sender);
+    }
+
+    test('stopSession emits one, carrying the stopped session', () async {
+      final (client, sender) = await createClient();
+      addTearDown(client.close);
+
+      final first = (await client.record('first') as Ok<EnrichedEvent>).value;
+      await client.stopSession();
+
+      expect(sender.sessionStops, hasLength(1));
+      final event = sender.sessionStops.single;
+      expect(event.eventType, zSessionStopEventType);
+      expect(event.session.id, first.session.id);
+      expect(event.session.stopTimestamp, isNotNull);
+      expect(event.session.duration, isNotNull);
+    });
+
+    test('close emits one for a running session', () async {
+      final (client, sender) = await createClient();
+
+      final first = (await client.record('first') as Ok<EnrichedEvent>).value;
+      await client.close();
+
+      expect(sender.sessionStops, hasLength(1));
+      expect(sender.sessionStops.single.session.id, first.session.id);
+    });
+
+    test('close after stopSession does not emit a second', () async {
+      final (client, sender) = await createClient();
+
+      await client.record('first');
+      await client.stopSession();
+      await client.close();
+
+      expect(sender.sessionStops, hasLength(1));
+    });
+
+    test('startSession emits one for the session it displaces', () async {
+      final (client, sender) = await createClient();
+      addTearDown(client.close);
+
+      final first = (await client.record('first') as Ok<EnrichedEvent>).value;
+      await client.startSession();
+
+      expect(sender.sessionStops, hasLength(1));
+      expect(sender.sessionStops.single.session.id, first.session.id);
+    });
+
+    test('close emits nothing when no session ever started', () async {
+      final (client, sender) = await createClient(autoSessionTracking: false);
+
+      await client.close();
+
+      expect(sender.sessionStops, isEmpty);
     });
   });
 }

--- a/packages/amplify_event_enrichment/amplify_event_enrichment/test/event_enrichment_client_flutter_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment/test/event_enrichment_client_flutter_test.dart
@@ -235,6 +235,37 @@ void main() {
       expect(sender.sessionEvents, isEmpty);
     });
 
+    test('create passes the initial user id and globals to the start', () async {
+      // create() resolves providers asynchronously before constructing the
+      // delegate, so the launch start is the first chance to stamp these and
+      // setUserId afterwards would already be too late for it.
+      final sender = _RecordingSender();
+      final client = await EventEnrichmentClientFlutter.create(
+        appId: 'test-app',
+        sdkMetadata: sdk,
+        sender: sender,
+        initialUserId: 'user-1',
+        initialGlobalAttributes: const {'env': 'prod'},
+        initialGlobalMetrics: const {'score': 4.5},
+      );
+      addTearDown(client.close);
+
+      final event = sender.sessionStarts.single;
+      expect(event.userId, 'user-1');
+      expect(event.attributes['env'], 'prod');
+      expect(event.metrics['score'], 4.5);
+    });
+
+    test('create leaves them absent when not supplied', () async {
+      final (client, sender) = await createClient();
+      addTearDown(client.close);
+
+      final event = sender.sessionStarts.single;
+      expect(event.userId, isNull);
+      expect(event.attributes, isEmpty);
+      expect(event.metrics, isEmpty);
+    });
+
     test('stopSession emits one stop, carrying the stopped session', () async {
       final (client, sender) = await createClient();
       addTearDown(client.close);

--- a/packages/amplify_event_enrichment/amplify_event_enrichment/test/event_enrichment_client_flutter_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment/test/event_enrichment_client_flutter_test.dart
@@ -32,8 +32,19 @@ class _RecordingSender implements Sender {
   @override
   Future<void> send(EnrichedEvent event) async => events.add(event);
 
-  /// Only the session-stop events, so counts are unaffected by whatever the
-  /// test recorded to get a session started.
+  /// Only the session-boundary events, so counts and ordering are unaffected by
+  /// whatever the test recorded to move a session along.
+  List<EnrichedEvent> get sessionEvents => events
+      .where(
+        (e) =>
+            e.eventType == zSessionStartEventType ||
+            e.eventType == zSessionStopEventType,
+      )
+      .toList();
+
+  List<EnrichedEvent> get sessionStarts =>
+      events.where((e) => e.eventType == zSessionStartEventType).toList();
+
   List<EnrichedEvent> get sessionStops =>
       events.where((e) => e.eventType == zSessionStopEventType).toList();
 }
@@ -188,7 +199,7 @@ void main() {
     });
   });
 
-  group('EventEnrichmentClientFlutter session stop events', () {
+  group('EventEnrichmentClientFlutter session events', () {
     Future<(EventEnrichmentClientFlutter, _RecordingSender)> createClient({
       bool autoSessionTracking = true,
     }) async {
@@ -204,7 +215,27 @@ void main() {
       return (client, sender);
     }
 
-    test('stopSession emits one, carrying the stopped session', () async {
+    test('create emits a start when autoSessionTracking is on', () async {
+      final (client, sender) = await createClient();
+      addTearDown(client.close);
+
+      final first = (await client.record('first') as Ok<EnrichedEvent>).value;
+
+      expect(sender.sessionStarts, hasLength(1));
+      final event = sender.sessionStarts.single;
+      expect(event.eventType, zSessionStartEventType);
+      expect(event.session.id, first.session.id);
+      expect(event.session.stopTimestamp, isNull);
+    });
+
+    test('create emits nothing when autoSessionTracking is off', () async {
+      final (client, sender) = await createClient(autoSessionTracking: false);
+      addTearDown(client.close);
+
+      expect(sender.sessionEvents, isEmpty);
+    });
+
+    test('stopSession emits one stop, carrying the stopped session', () async {
       final (client, sender) = await createClient();
       addTearDown(client.close);
 
@@ -219,7 +250,7 @@ void main() {
       expect(event.session.duration, isNotNull);
     });
 
-    test('close emits one for a running session', () async {
+    test('close emits one stop for a running session', () async {
       final (client, sender) = await createClient();
 
       final first = (await client.record('first') as Ok<EnrichedEvent>).value;
@@ -229,7 +260,7 @@ void main() {
       expect(sender.sessionStops.single.session.id, first.session.id);
     });
 
-    test('close after stopSession does not emit a second', () async {
+    test('close after stopSession does not emit a second stop', () async {
       final (client, sender) = await createClient();
 
       await client.record('first');
@@ -239,15 +270,20 @@ void main() {
       expect(sender.sessionStops, hasLength(1));
     });
 
-    test('startSession emits one for the session it displaces', () async {
+    test('startSession emits the displaced stop then the new start', () async {
       final (client, sender) = await createClient();
       addTearDown(client.close);
 
       final first = (await client.record('first') as Ok<EnrichedEvent>).value;
       await client.startSession();
 
-      expect(sender.sessionStops, hasLength(1));
+      expect(sender.sessionEvents.map((e) => e.eventType), [
+        zSessionStartEventType,
+        zSessionStopEventType,
+        zSessionStartEventType,
+      ]);
       expect(sender.sessionStops.single.session.id, first.session.id);
+      expect(sender.sessionStarts.last.session.id, isNot(first.session.id));
     });
 
     test('close emits nothing when no session ever started', () async {
@@ -255,7 +291,7 @@ void main() {
 
       await client.close();
 
-      expect(sender.sessionStops, isEmpty);
+      expect(sender.sessionEvents, isEmpty);
     });
   });
 }

--- a/packages/amplify_event_enrichment/amplify_event_enrichment/test/event_enrichment_client_flutter_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment/test/event_enrichment_client_flutter_test.dart
@@ -135,6 +135,32 @@ void main() {
       expect(second.session.id, first.session.id);
     });
 
+    test(
+      'record after a stop and a lifecycle cycle gets a fresh session',
+      () async {
+        final client = await EventEnrichmentClientFlutter.create(
+          appId: 'test-app',
+          sdkMetadata: sdk,
+        );
+        addTearDown(client.close);
+
+        final first = (await client.record('first') as Ok<EnrichedEvent>).value;
+        client
+          ..stopSession()
+          ..handleAppPaused()
+          ..handleAppResumed();
+
+        final second =
+            (await client.record('second') as Ok<EnrichedEvent>).value;
+        expect(second.session.id, isNot(first.session.id));
+        expect(second.session.stopTimestamp, isNull);
+      },
+    );
+    // Note: that a resume does not itself resurrect the stopped session is
+    // asserted in flutter_lifecycle_observer_test.dart, which can observe
+    // SessionManager state. The wrapper deliberately does not expose it, so
+    // both outcomes look the same through record() alone.
+
     test('records with autoSessionTracking disabled', () async {
       // No session is started up front and no lifecycle observer is installed,
       // but the first record() lazily starts one.

--- a/packages/amplify_event_enrichment/amplify_event_enrichment/test/event_enrichment_client_flutter_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment/test/event_enrichment_client_flutter_test.dart
@@ -26,7 +26,7 @@ class _ThrowingClientIdProvider implements ClientIdProvider {
   Future<String> getClientId() async => throw StateError('provider failure');
 }
 
-class _RecordingSender implements Sender {
+class _RecordingSender implements EnrichedEventSender {
   final List<EnrichedEvent> events = [];
 
   @override

--- a/packages/amplify_event_enrichment/amplify_event_enrichment/test/event_enrichment_client_flutter_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment/test/event_enrichment_client_flutter_test.dart
@@ -12,6 +12,20 @@ class _ThrowingDeviceMetadataProvider implements DeviceMetadataProvider {
       throw StateError('provider failure');
 }
 
+class _FixedClientIdProvider implements ClientIdProvider {
+  const _FixedClientIdProvider(this.id);
+
+  final String id;
+
+  @override
+  Future<String> getClientId() async => id;
+}
+
+class _ThrowingClientIdProvider implements ClientIdProvider {
+  @override
+  Future<String> getClientId() async => throw StateError('provider failure');
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -19,22 +33,120 @@ void main() {
     SharedPreferences.setMockInitialValues({});
   });
 
+  const sdk = SdkMetadata(name: 'amplify-flutter', version: '2.0.0');
+
   group('EventEnrichmentClientFlutter.create', () {
     test('degrades gracefully when device metadata resolution fails', () async {
       // create() must not throw when a provider fails; it falls back to empty
       // device metadata and the client stays usable.
       final client = await EventEnrichmentClientFlutter.create(
         appId: 'test-app',
-        sdkMetadata: const SdkMetadata(
-          name: 'amplify-flutter',
-          version: '2.0.0',
-        ),
+        sdkMetadata: sdk,
         deviceMetadataProvider: _ThrowingDeviceMetadataProvider(),
       );
       addTearDown(client.close);
 
-      final result = client.record('event');
+      final result = await client.record('event');
       expect(result, isA<Ok<EnrichedEvent>>());
+    });
+
+    test('uses an injected clientIdProvider', () async {
+      final client = await EventEnrichmentClientFlutter.create(
+        appId: 'test-app',
+        sdkMetadata: sdk,
+        clientIdProvider: const _FixedClientIdProvider('injected-id'),
+      );
+      addTearDown(client.close);
+
+      final event = (await client.record('event') as Ok<EnrichedEvent>).value;
+      expect(event.clientId, 'injected-id');
+    });
+
+    test('degrades gracefully when clientIdProvider fails', () async {
+      final client = await EventEnrichmentClientFlutter.create(
+        appId: 'test-app',
+        sdkMetadata: sdk,
+        clientIdProvider: _ThrowingClientIdProvider(),
+      );
+      addTearDown(client.close);
+
+      // Falls back to an ephemeral id rather than throwing out of create().
+      final event = (await client.record('event') as Ok<EnrichedEvent>).value;
+      expect(event.clientId, isNotEmpty);
+    });
+
+    test('defaults to the shared preferences client ID', () async {
+      final client = await EventEnrichmentClientFlutter.create(
+        appId: 'test-app',
+        sdkMetadata: sdk,
+      );
+      addTearDown(client.close);
+
+      final event = (await client.record('event') as Ok<EnrichedEvent>).value;
+      final persisted = await const SharedPreferencesClientIdProvider()
+          .getClientId();
+      expect(event.clientId, persisted);
+    });
+  });
+
+  group('EventEnrichmentClientFlutter session controls', () {
+    test('stopSession then record starts a fresh session', () async {
+      final client = await EventEnrichmentClientFlutter.create(
+        appId: 'test-app',
+        sdkMetadata: sdk,
+      );
+      addTearDown(client.close);
+
+      final first = (await client.record('first') as Ok<EnrichedEvent>).value;
+      client.stopSession();
+      final second = (await client.record('second') as Ok<EnrichedEvent>).value;
+
+      expect(second.session.id, isNot(first.session.id));
+      expect(second.session.stopTimestamp, isNull);
+    });
+
+    test('startSession begins a new session', () async {
+      final client = await EventEnrichmentClientFlutter.create(
+        appId: 'test-app',
+        sdkMetadata: sdk,
+      );
+      addTearDown(client.close);
+
+      final first = (await client.record('first') as Ok<EnrichedEvent>).value;
+      client.startSession();
+      final second = (await client.record('second') as Ok<EnrichedEvent>).value;
+
+      expect(second.session.id, isNot(first.session.id));
+    });
+
+    test('handleAppPaused then handleAppResumed keeps the session', () async {
+      final client = await EventEnrichmentClientFlutter.create(
+        appId: 'test-app',
+        sdkMetadata: sdk,
+      );
+      addTearDown(client.close);
+
+      final first = (await client.record('first') as Ok<EnrichedEvent>).value;
+      client
+        ..handleAppPaused()
+        ..handleAppResumed();
+      final second = (await client.record('second') as Ok<EnrichedEvent>).value;
+
+      expect(second.session.id, first.session.id);
+    });
+
+    test('records with autoSessionTracking disabled', () async {
+      // No session is started up front and no lifecycle observer is installed,
+      // but the first record() lazily starts one.
+      final client = await EventEnrichmentClientFlutter.create(
+        appId: 'test-app',
+        sdkMetadata: sdk,
+        options: const EventEnrichmentClientOptions(autoSessionTracking: false),
+      );
+      addTearDown(client.close);
+
+      final event = (await client.record('event') as Ok<EnrichedEvent>).value;
+      expect(event.session.id, isNotEmpty);
     });
   });
 }

--- a/packages/amplify_event_enrichment/amplify_event_enrichment/test/flutter_lifecycle_observer_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment/test/flutter_lifecycle_observer_test.dart
@@ -1,0 +1,63 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_event_enrichment/amplify_event_enrichment.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('FlutterLifecycleObserver', () {
+    late SessionManager sessionManager;
+    late FlutterLifecycleObserver observer;
+
+    setUp(() {
+      sessionManager = SessionManager(
+        appId: 'testApp1',
+        sessionTimeout: const Duration(seconds: 5),
+        generateId: () => 'uuid0000-fake-uuid-value',
+      );
+      sessionManager.startSession();
+      observer = FlutterLifecycleObserver(sessionManager: sessionManager);
+    });
+
+    tearDown(() {
+      observer.dispose();
+    });
+
+    test('onPause calls sessionManager.handleAppPaused', () {
+      observer.onPause();
+      expect(sessionManager.state, SessionState.paused);
+    });
+
+    test('onResume calls sessionManager.handleAppResumed', () {
+      observer.onPause();
+      observer.onResume();
+      expect(sessionManager.state, SessionState.active);
+    });
+
+    test('didChangeAppLifecycleState paused triggers onPause', () {
+      observer.didChangeAppLifecycleState(AppLifecycleState.paused);
+      expect(sessionManager.state, SessionState.paused);
+    });
+
+    test('didChangeAppLifecycleState hidden triggers onPause', () {
+      observer.didChangeAppLifecycleState(AppLifecycleState.hidden);
+      expect(sessionManager.state, SessionState.paused);
+    });
+
+    test('didChangeAppLifecycleState resumed triggers onResume', () {
+      observer.didChangeAppLifecycleState(AppLifecycleState.paused);
+      observer.didChangeAppLifecycleState(AppLifecycleState.resumed);
+      expect(sessionManager.state, SessionState.active);
+    });
+
+    test('dispose removes observer without error', () {
+      // Should not throw.
+      observer.dispose();
+      // Calling again should be safe (removeObserver is idempotent).
+      observer.dispose();
+    });
+  });
+}

--- a/packages/amplify_event_enrichment/amplify_event_enrichment/test/flutter_lifecycle_observer_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment/test/flutter_lifecycle_observer_test.dart
@@ -17,8 +17,7 @@ void main() {
         appId: 'testApp1',
         sessionTimeout: const Duration(seconds: 5),
         generateId: () => 'uuid0000-fake-uuid-value',
-      );
-      sessionManager.startSession();
+      )..startSession();
       observer = FlutterLifecycleObserver(sessionManager: sessionManager);
     });
 
@@ -32,8 +31,9 @@ void main() {
     });
 
     test('onResume calls sessionManager.handleAppResumed', () {
-      observer.onPause();
-      observer.onResume();
+      observer
+        ..onPause()
+        ..onResume();
       expect(sessionManager.state, SessionState.active);
     });
 
@@ -48,16 +48,17 @@ void main() {
     });
 
     test('didChangeAppLifecycleState resumed triggers onResume', () {
-      observer.didChangeAppLifecycleState(AppLifecycleState.paused);
-      observer.didChangeAppLifecycleState(AppLifecycleState.resumed);
+      observer
+        ..didChangeAppLifecycleState(AppLifecycleState.paused)
+        ..didChangeAppLifecycleState(AppLifecycleState.resumed);
       expect(sessionManager.state, SessionState.active);
     });
 
     test('dispose removes observer without error', () {
-      // Should not throw.
-      observer.dispose();
-      // Calling again should be safe (removeObserver is idempotent).
-      observer.dispose();
+      // Calling dispose twice should be safe (removeObserver is idempotent).
+      observer
+        ..dispose()
+        ..dispose();
     });
   });
 }

--- a/packages/amplify_event_enrichment/amplify_event_enrichment/test/flutter_lifecycle_observer_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment/test/flutter_lifecycle_observer_test.dart
@@ -60,5 +60,34 @@ void main() {
         ..dispose()
         ..dispose();
     });
+
+    test('onResume does not restart a session stopped explicitly', () {
+      observer.onPause();
+      sessionManager.stopSession();
+      final stoppedId = sessionManager.session!.id;
+
+      observer.onResume();
+
+      expect(
+        sessionManager.state,
+        SessionState.stopped,
+        reason: 'the lifecycle observer must not resurrect a stopped session',
+      );
+      expect(sessionManager.session!.id, stoppedId);
+    });
+
+    test(
+      'a resumed lifecycle event does not restart after an explicit stop',
+      () {
+        // Same assertion driven through the real WidgetsBindingObserver entry
+        // point rather than onPause/onResume directly.
+        observer.didChangeAppLifecycleState(AppLifecycleState.paused);
+        sessionManager.stopSession();
+
+        observer.didChangeAppLifecycleState(AppLifecycleState.resumed);
+
+        expect(sessionManager.state, SessionState.stopped);
+      },
+    );
   });
 }

--- a/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/device_metadata_provider_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/device_metadata_provider_test.dart
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_event_enrichment_dart/amplify_event_enrichment.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('PlatformDeviceMetadataProvider', () {
+    // On the VM this exercises the dart:io resolver; on web the conditional
+    // import selects the stub, which returns empty metadata. Either way the
+    // default provider must resolve without throwing.
+    test('resolves device metadata without throwing', () async {
+      const provider = PlatformDeviceMetadataProvider();
+      final metadata = await provider.getDeviceMetadata();
+      expect(metadata, isA<DeviceMetadata>());
+    });
+
+    test('satisfies the DeviceMetadataProvider interface', () async {
+      const DeviceMetadataProvider provider = PlatformDeviceMetadataProvider();
+      expect(await provider.getDeviceMetadata(), isA<DeviceMetadata>());
+    });
+  });
+}

--- a/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/device_metadata_provider_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/device_metadata_provider_test.dart
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import 'package:amplify_event_enrichment_dart/amplify_event_enrichment.dart';
+import 'package:amplify_event_enrichment_dart/amplify_event_enrichment_dart.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/enriched_event_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/enriched_event_test.dart
@@ -11,31 +11,31 @@ void main() {
     late EnrichedEvent event;
 
     setUp(() {
-      event = EnrichedEvent(
+      event = const EnrichedEvent(
         eventId: 'test-event-id',
         eventType: 'product_viewed',
         eventTimestamp: 1700000000000,
-        session: const Session(
+        session: Session(
           id: 'testApp1-uuid0000-20231114-120000000',
           startTimestamp: '2023-11-14T12:00:00.000Z',
         ),
         attributes: {'category': 'electronics'},
         metrics: {'price': 29.99},
-        device: const DeviceMetadata(
+        device: DeviceMetadata(
           platform: 'iOS',
           platformVersion: '17.0',
           manufacturer: 'Apple',
           model: 'iPhone 15',
           locale: 'en_US',
         ),
-        app: const AppMetadata(
+        app: AppMetadata(
           appId: 'testApp1',
           packageName: 'com.example.app',
           versionName: '1.0.0',
           versionCode: '1',
           title: 'Test App',
         ),
-        sdk: const SdkMetadata(name: 'amplify-flutter', version: '2.0.0'),
+        sdk: SdkMetadata(name: 'amplify-flutter', version: '2.0.0'),
         clientId: 'device-uuid-123',
         userId: 'user-42',
       );
@@ -79,16 +79,16 @@ void main() {
     });
 
     test('omits user_id when null', () {
-      final noUser = EnrichedEvent(
+      const noUser = EnrichedEvent(
         eventId: 'id',
         eventType: 'test',
         eventTimestamp: 0,
-        session: const Session(id: 's', startTimestamp: 't'),
-        attributes: const {},
-        metrics: const {},
-        device: const DeviceMetadata(),
-        app: const AppMetadata(appId: 'a'),
-        sdk: const SdkMetadata(name: 'n', version: 'v'),
+        session: Session(id: 's', startTimestamp: 't'),
+        attributes: {},
+        metrics: {},
+        device: DeviceMetadata(),
+        app: AppMetadata(appId: 'a'),
+        sdk: SdkMetadata(name: 'n', version: 'v'),
         clientId: 'c',
       );
       final map = jsonDecode(noUser.toJson()) as Map<String, dynamic>;
@@ -121,16 +121,16 @@ void main() {
     });
 
     test('omits attributes and metrics when empty', () {
-      final empty = EnrichedEvent(
+      const empty = EnrichedEvent(
         eventId: 'id',
         eventType: 'test',
         eventTimestamp: 0,
-        session: const Session(id: 's', startTimestamp: 't'),
-        attributes: const {},
-        metrics: const {},
-        device: const DeviceMetadata(),
-        app: const AppMetadata(appId: 'a'),
-        sdk: const SdkMetadata(name: 'n', version: 'v'),
+        session: Session(id: 's', startTimestamp: 't'),
+        attributes: {},
+        metrics: {},
+        device: DeviceMetadata(),
+        app: AppMetadata(appId: 'a'),
+        sdk: SdkMetadata(name: 'n', version: 'v'),
         clientId: 'c',
       );
       final map = jsonDecode(empty.toJson()) as Map<String, dynamic>;

--- a/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/enriched_event_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/enriched_event_test.dart
@@ -1,0 +1,141 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'dart:convert';
+
+import 'package:amplify_event_enrichment_dart/amplify_event_enrichment.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('EnrichedEvent.toJson()', () {
+    late EnrichedEvent event;
+
+    setUp(() {
+      event = EnrichedEvent(
+        eventId: 'test-event-id',
+        eventType: 'product_viewed',
+        eventTimestamp: 1700000000000,
+        session: const Session(
+          id: 'testApp1-uuid0000-20231114-120000000',
+          startTimestamp: '2023-11-14T12:00:00.000Z',
+        ),
+        attributes: {'category': 'electronics'},
+        metrics: {'price': 29.99},
+        device: const DeviceMetadata(
+          platform: 'iOS',
+          platformVersion: '17.0',
+          manufacturer: 'Apple',
+          model: 'iPhone 15',
+          locale: 'en_US',
+        ),
+        app: const AppMetadata(
+          appId: 'testApp1',
+          packageName: 'com.example.app',
+          versionName: '1.0.0',
+          versionCode: '1',
+          title: 'Test App',
+        ),
+        sdk: const SdkMetadata(name: 'amplify-flutter', version: '2.0.0'),
+        clientId: 'device-uuid-123',
+        userId: 'user-42',
+      );
+    });
+
+    test('produces valid JSON', () {
+      final json = event.toJson();
+      expect(() => jsonDecode(json), returnsNormally);
+    });
+
+    test('contains event_type and event_version', () {
+      final map = jsonDecode(event.toJson()) as Map<String, dynamic>;
+      expect(map['event_type'], 'product_viewed');
+      expect(map['event_version'], '3.1');
+    });
+
+    test('contains timestamps', () {
+      final map = jsonDecode(event.toJson()) as Map<String, dynamic>;
+      expect(map['event_timestamp'], 1700000000000);
+      expect(map['arrival_timestamp'], 1700000000000);
+    });
+
+    test('contains application with sdk nested', () {
+      final map = jsonDecode(event.toJson()) as Map<String, dynamic>;
+      final app = map['application'] as Map<String, dynamic>;
+      expect(app['app_id'], 'testApp1');
+      expect(app['package_name'], 'com.example.app');
+      expect(app['version_name'], '1.0.0');
+      expect(app['version_code'], '1');
+      expect(app['title'], 'Test App');
+      final sdk = app['sdk'] as Map<String, dynamic>;
+      expect(sdk['name'], 'amplify-flutter');
+      expect(sdk['version'], '2.0.0');
+    });
+
+    test('contains client with user_id', () {
+      final map = jsonDecode(event.toJson()) as Map<String, dynamic>;
+      final client = map['client'] as Map<String, dynamic>;
+      expect(client['client_id'], 'device-uuid-123');
+      expect(client['user_id'], 'user-42');
+    });
+
+    test('omits user_id when null', () {
+      final noUser = EnrichedEvent(
+        eventId: 'id',
+        eventType: 'test',
+        eventTimestamp: 0,
+        session: const Session(id: 's', startTimestamp: 't'),
+        attributes: const {},
+        metrics: const {},
+        device: const DeviceMetadata(),
+        app: const AppMetadata(appId: 'a'),
+        sdk: const SdkMetadata(name: 'n', version: 'v'),
+        clientId: 'c',
+      );
+      final map = jsonDecode(noUser.toJson()) as Map<String, dynamic>;
+      final client = map['client'] as Map<String, dynamic>;
+      expect(client.containsKey('user_id'), isFalse);
+    });
+
+    test('contains device with platform nested', () {
+      final map = jsonDecode(event.toJson()) as Map<String, dynamic>;
+      final device = map['device'] as Map<String, dynamic>;
+      final platform = device['platform'] as Map<String, dynamic>;
+      expect(platform['name'], 'iOS');
+      expect(platform['version'], '17.0');
+      expect(device['make'], 'Apple');
+      expect(device['model'], 'iPhone 15');
+      expect((device['locale'] as Map)['code'], 'en_US');
+    });
+
+    test('contains session fields', () {
+      final map = jsonDecode(event.toJson()) as Map<String, dynamic>;
+      final session = map['session'] as Map<String, dynamic>;
+      expect(session['id'], contains('testApp1'));
+      expect(session['start_timestamp'], '2023-11-14T12:00:00.000Z');
+    });
+
+    test('contains attributes and metrics', () {
+      final map = jsonDecode(event.toJson()) as Map<String, dynamic>;
+      expect(map['attributes'], {'category': 'electronics'});
+      expect(map['metrics'], {'price': 29.99});
+    });
+
+    test('omits attributes and metrics when empty', () {
+      final empty = EnrichedEvent(
+        eventId: 'id',
+        eventType: 'test',
+        eventTimestamp: 0,
+        session: const Session(id: 's', startTimestamp: 't'),
+        attributes: const {},
+        metrics: const {},
+        device: const DeviceMetadata(),
+        app: const AppMetadata(appId: 'a'),
+        sdk: const SdkMetadata(name: 'n', version: 'v'),
+        clientId: 'c',
+      );
+      final map = jsonDecode(empty.toJson()) as Map<String, dynamic>;
+      expect(map.containsKey('attributes'), isFalse);
+      expect(map.containsKey('metrics'), isFalse);
+    });
+  });
+}

--- a/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/enriched_event_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/enriched_event_test.dart
@@ -3,7 +3,7 @@
 
 import 'dart:convert';
 
-import 'package:amplify_event_enrichment_dart/amplify_event_enrichment.dart';
+import 'package:amplify_event_enrichment_dart/amplify_event_enrichment_dart.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/enriched_event_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/enriched_event_test.dart
@@ -41,25 +41,27 @@ void main() {
       );
     });
 
-    test('produces valid JSON', () {
-      final json = event.toJson();
-      expect(() => jsonDecode(json), returnsNormally);
+    test('produces a JSON-encodable map', () {
+      final map = event.toJson();
+      expect(map, isA<Map<String, dynamic>>());
+      // Round-trip through jsonEncode to verify all values are encodable.
+      expect(() => jsonEncode(map), returnsNormally);
     });
 
     test('contains event_type and event_version', () {
-      final map = jsonDecode(event.toJson()) as Map<String, dynamic>;
+      final map = event.toJson();
       expect(map['event_type'], 'product_viewed');
       expect(map['event_version'], '3.1');
     });
 
     test('contains timestamps', () {
-      final map = jsonDecode(event.toJson()) as Map<String, dynamic>;
+      final map = event.toJson();
       expect(map['event_timestamp'], 1700000000000);
       expect(map['arrival_timestamp'], 1700000000000);
     });
 
     test('contains application with sdk nested', () {
-      final map = jsonDecode(event.toJson()) as Map<String, dynamic>;
+      final map = event.toJson();
       final app = map['application'] as Map<String, dynamic>;
       expect(app['app_id'], 'testApp1');
       expect(app['package_name'], 'com.example.app');
@@ -72,7 +74,7 @@ void main() {
     });
 
     test('contains client with user_id', () {
-      final map = jsonDecode(event.toJson()) as Map<String, dynamic>;
+      final map = event.toJson();
       final client = map['client'] as Map<String, dynamic>;
       expect(client['client_id'], 'device-uuid-123');
       expect(client['user_id'], 'user-42');
@@ -91,13 +93,13 @@ void main() {
         sdk: SdkMetadata(name: 'n', version: 'v'),
         clientId: 'c',
       );
-      final map = jsonDecode(noUser.toJson()) as Map<String, dynamic>;
+      final map = noUser.toJson();
       final client = map['client'] as Map<String, dynamic>;
       expect(client.containsKey('user_id'), isFalse);
     });
 
     test('contains device with platform nested', () {
-      final map = jsonDecode(event.toJson()) as Map<String, dynamic>;
+      final map = event.toJson();
       final device = map['device'] as Map<String, dynamic>;
       final platform = device['platform'] as Map<String, dynamic>;
       expect(platform['name'], 'iOS');
@@ -108,14 +110,14 @@ void main() {
     });
 
     test('contains session fields', () {
-      final map = jsonDecode(event.toJson()) as Map<String, dynamic>;
+      final map = event.toJson();
       final session = map['session'] as Map<String, dynamic>;
       expect(session['id'], contains('testApp1'));
       expect(session['start_timestamp'], '2023-11-14T12:00:00.000Z');
     });
 
     test('contains attributes and metrics', () {
-      final map = jsonDecode(event.toJson()) as Map<String, dynamic>;
+      final map = event.toJson();
       expect(map['attributes'], {'category': 'electronics'});
       expect(map['metrics'], {'price': 29.99});
     });
@@ -133,9 +135,28 @@ void main() {
         sdk: SdkMetadata(name: 'n', version: 'v'),
         clientId: 'c',
       );
-      final map = jsonDecode(empty.toJson()) as Map<String, dynamic>;
+      final map = empty.toJson();
       expect(map.containsKey('attributes'), isFalse);
       expect(map.containsKey('metrics'), isFalse);
+    });
+
+    test('map contains all expected top-level keys', () {
+      final map = event.toJson();
+      expect(
+        map.keys,
+        containsAll([
+          'event_type',
+          'event_timestamp',
+          'arrival_timestamp',
+          'event_version',
+          'application',
+          'client',
+          'device',
+          'session',
+          'attributes',
+          'metrics',
+        ]),
+      );
     });
   });
 }

--- a/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/event_enrichment_client_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/event_enrichment_client_test.dart
@@ -12,6 +12,11 @@ class _MockSink implements EventSink {
   void send(EnrichedEvent event) => events.add(event);
 }
 
+class _ThrowingSink implements EventSink {
+  @override
+  void send(EnrichedEvent event) => throw StateError('sink failure');
+}
+
 void main() {
   group('EventEnrichmentClient', () {
     late EventEnrichmentClient client;
@@ -157,6 +162,25 @@ void main() {
         secondEvent.session.stopTimestamp,
         isNull,
         reason: 'the fresh session must not carry a stop_timestamp',
+      );
+    });
+
+    test('record() surfaces a sink failure through Result.error', () {
+      final throwingClient = EventEnrichmentClient(
+        appMetadata: app,
+        deviceMetadata: device,
+        sdkMetadata: sdk,
+        clientId: 'device-123',
+        sink: _ThrowingSink(),
+      );
+      addTearDown(throwingClient.close);
+
+      // Must return an Error result rather than throwing out of record().
+      final result = throwingClient.record('boom');
+      expect(result, isA<Error<EnrichedEvent>>());
+      expect(
+        (result as Error<EnrichedEvent>).error,
+        isA<EventEnrichmentRecordException>(),
       );
     });
   });

--- a/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/event_enrichment_client_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/event_enrichment_client_test.dart
@@ -1,0 +1,139 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_event_enrichment_dart/amplify_event_enrichment.dart';
+import 'package:amplify_foundation_dart/amplify_foundation_dart.dart';
+import 'package:test/test.dart';
+
+class _MockSink implements EventSink {
+  final List<EnrichedEvent> events = [];
+
+  @override
+  void send(EnrichedEvent event) => events.add(event);
+}
+
+void main() {
+  group('EventEnrichmentClient', () {
+    late EventEnrichmentClient client;
+    late _MockSink sink;
+
+    const app = AppMetadata(
+      appId: 'testApp1',
+      packageName: 'com.example',
+      versionName: '1.0.0',
+      title: 'Test',
+    );
+    const device = DeviceMetadata(
+      platform: 'iOS',
+      platformVersion: '17.0',
+      manufacturer: 'Apple',
+      model: 'iPhone',
+      locale: 'en_US',
+    );
+    const sdk = SdkMetadata(name: 'amplify-flutter', version: '2.0.0');
+
+    setUp(() {
+      sink = _MockSink();
+      client = EventEnrichmentClient(
+        appMetadata: app,
+        deviceMetadata: device,
+        sdkMetadata: sdk,
+        clientId: 'device-123',
+        sink: sink,
+      );
+    });
+
+    tearDown(() {
+      if (!client.isClosed) client.close();
+    });
+
+    test('record() returns Ok with correct metadata', () {
+      final result = client.record('test_event');
+      expect(result, isA<Ok<EnrichedEvent>>());
+      final event = (result as Ok<EnrichedEvent>).value;
+      expect(event.eventType, 'test_event');
+      expect(event.app.appId, 'testApp1');
+      expect(event.device.platform, 'iOS');
+      expect(event.sdk.name, 'amplify-flutter');
+      expect(event.clientId, 'device-123');
+      expect(event.session.id, isNotEmpty);
+    });
+
+    test('record() dispatches to sink when configured', () {
+      client.record('test_event');
+      expect(sink.events, hasLength(1));
+      expect(sink.events.first.eventType, 'test_event');
+    });
+
+    test('record() does not fail when sink is null', () {
+      final noSinkClient = EventEnrichmentClient(
+        appMetadata: app,
+        deviceMetadata: device,
+        sdkMetadata: sdk,
+        clientId: 'c',
+      );
+      final result = noSinkClient.record('test');
+      expect(result, isA<Ok<EnrichedEvent>>());
+      noSinkClient.close();
+    });
+
+    test('record() returns Error after close()', () {
+      client.close();
+      final result = client.record('test');
+      expect(result, isA<Error<EnrichedEvent>>());
+    });
+
+    test('per-event attributes override globals', () {
+      client.addGlobalAttribute('key', 'global');
+      final event =
+          (client.record('test', attributes: {'key': 'local'})
+              as Ok<EnrichedEvent>).value;
+      expect(event.attributes['key'], 'local');
+    });
+
+    test('per-event metrics override globals', () {
+      client.addGlobalMetric('m', 1.0);
+      final event =
+          (client.record('test', metrics: {'m': 2.0})
+              as Ok<EnrichedEvent>).value;
+      expect(event.metrics['m'], 2.0);
+    });
+
+    test('global attributes appear on events', () {
+      client.addGlobalAttribute('env', 'prod');
+      final event = (client.record('test') as Ok<EnrichedEvent>).value;
+      expect(event.attributes['env'], 'prod');
+    });
+
+    test('removed global attributes do not appear', () {
+      client.addGlobalAttribute('env', 'prod');
+      client.removeGlobalAttribute('env');
+      final event = (client.record('test') as Ok<EnrichedEvent>).value;
+      expect(event.attributes.containsKey('env'), isFalse);
+    });
+
+    test('setUserId appears on subsequent events', () {
+      client.setUserId('user-1');
+      final event = (client.record('test') as Ok<EnrichedEvent>).value;
+      expect(event.userId, 'user-1');
+    });
+
+    test('setUserId(null) clears userId', () {
+      client.setUserId('user-1');
+      client.setUserId(null);
+      final event = (client.record('test') as Ok<EnrichedEvent>).value;
+      expect(event.userId, isNull);
+    });
+
+    test('handleAppPaused and handleAppResumed maintain session', () {
+      final firstEvent = (client.record('before') as Ok<EnrichedEvent>).value;
+      final sessionId = firstEvent.session.id;
+
+      client.handleAppPaused();
+      client.handleAppResumed();
+
+      final secondEvent = (client.record('after') as Ok<EnrichedEvent>).value;
+      expect(secondEvent.session.id, sessionId);
+    });
+  });
+}

--- a/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/event_enrichment_client_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/event_enrichment_client_test.dart
@@ -87,15 +87,16 @@ void main() {
       client.addGlobalAttribute('key', 'global');
       final event =
           (client.record('test', attributes: {'key': 'local'})
-              as Ok<EnrichedEvent>).value;
+                  as Ok<EnrichedEvent>)
+              .value;
       expect(event.attributes['key'], 'local');
     });
 
     test('per-event metrics override globals', () {
-      client.addGlobalMetric('m', 1.0);
+      client.addGlobalMetric('m', 1);
       final event =
-          (client.record('test', metrics: {'m': 2.0})
-              as Ok<EnrichedEvent>).value;
+          (client.record('test', metrics: {'m': 2.0}) as Ok<EnrichedEvent>)
+              .value;
       expect(event.metrics['m'], 2.0);
     });
 
@@ -106,8 +107,9 @@ void main() {
     });
 
     test('removed global attributes do not appear', () {
-      client.addGlobalAttribute('env', 'prod');
-      client.removeGlobalAttribute('env');
+      client
+        ..addGlobalAttribute('env', 'prod')
+        ..removeGlobalAttribute('env');
       final event = (client.record('test') as Ok<EnrichedEvent>).value;
       expect(event.attributes.containsKey('env'), isFalse);
     });
@@ -119,8 +121,9 @@ void main() {
     });
 
     test('setUserId(null) clears userId', () {
-      client.setUserId('user-1');
-      client.setUserId(null);
+      client
+        ..setUserId('user-1')
+        ..setUserId(null);
       final event = (client.record('test') as Ok<EnrichedEvent>).value;
       expect(event.userId, isNull);
     });
@@ -129,8 +132,9 @@ void main() {
       final firstEvent = (client.record('before') as Ok<EnrichedEvent>).value;
       final sessionId = firstEvent.session.id;
 
-      client.handleAppPaused();
-      client.handleAppResumed();
+      client
+        ..handleAppPaused()
+        ..handleAppResumed();
 
       final secondEvent = (client.record('after') as Ok<EnrichedEvent>).value;
       expect(secondEvent.session.id, sessionId);

--- a/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/event_enrichment_client_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/event_enrichment_client_test.dart
@@ -135,5 +135,25 @@ void main() {
       final secondEvent = (client.record('after') as Ok<EnrichedEvent>).value;
       expect(secondEvent.session.id, sessionId);
     });
+
+    test('record() after stopSession() starts a fresh session', () {
+      final firstEvent = (client.record('first') as Ok<EnrichedEvent>).value;
+      final firstSessionId = firstEvent.session.id;
+      expect(firstEvent.session.stopTimestamp, isNull);
+
+      client.stopSession();
+
+      final secondEvent = (client.record('second') as Ok<EnrichedEvent>).value;
+      expect(
+        secondEvent.session.id,
+        isNot(firstSessionId),
+        reason: 'a stopped session must not be reused on the next record()',
+      );
+      expect(
+        secondEvent.session.stopTimestamp,
+        isNull,
+        reason: 'the fresh session must not carry a stop_timestamp',
+      );
+    });
   });
 }

--- a/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/event_enrichment_client_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/event_enrichment_client_test.dart
@@ -59,8 +59,8 @@ void main() {
       );
     });
 
-    tearDown(() {
-      if (!client.isClosed) client.close();
+    tearDown(() async {
+      if (!client.isClosed) await client.close();
     });
 
     test('record() returns Ok with correct metadata', () async {
@@ -90,11 +90,11 @@ void main() {
       );
       final result = await noSenderClient.record('test');
       expect(result, isA<Ok<EnrichedEvent>>());
-      noSenderClient.close();
+      await noSenderClient.close();
     });
 
     test('record() returns Error after close()', () async {
-      client.close();
+      await client.close();
       final result = await client.record('test');
       expect(result, isA<Error<EnrichedEvent>>());
     });
@@ -165,7 +165,7 @@ void main() {
       final firstSessionId = firstEvent.session.id;
       expect(firstEvent.session.stopTimestamp, isNull);
 
-      client.stopSession();
+      await client.stopSession();
 
       final secondEvent =
           (await client.record('second') as Ok<EnrichedEvent>).value;
@@ -187,9 +187,8 @@ void main() {
         await client.record('first');
         final stopped = client.sessionManager.session!;
 
-        client
-          ..stopSession()
-          ..handleAppResumed();
+        await client.stopSession();
+        client.handleAppResumed();
 
         expect(client.sessionManager.state, SessionState.stopped);
         expect(client.sessionManager.session!.id, stopped.id);
@@ -199,7 +198,7 @@ void main() {
     test('record() still starts a session after an explicit stop', () async {
       // The lazy start in record() is deliberately unaffected by the explicit
       // stop flag: recording an event always produces one with a session.
-      client.stopSession();
+      await client.stopSession();
       final result = await client.record('after_stop');
       expect(result, isA<Ok<EnrichedEvent>>());
       expect(client.sessionManager.state, SessionState.active);
@@ -208,9 +207,8 @@ void main() {
 
     test('close() drops the session and blocks lifecycle restarts', () async {
       await client.record('before_close');
-      client
-        ..close()
-        ..handleAppResumed();
+      await client.close();
+      client.handleAppResumed();
 
       expect(client.sessionManager.session, isNull);
       expect(client.sessionManager.state, SessionState.stopped);

--- a/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/event_enrichment_client_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/event_enrichment_client_test.dart
@@ -77,8 +77,11 @@ void main() {
 
     test('record() dispatches to the sender when configured', () async {
       await client.record('test_event');
-      expect(sender.events, hasLength(1));
-      expect(sender.events.first.eventType, 'test_event');
+      // The client eagerly starts a session, so its _session.start event
+      // precedes the recorded one. session_event_test.dart covers that
+      // behaviour; here only the recorded event matters.
+      expect(sender.events, hasLength(2));
+      expect(sender.events.last.eventType, 'test_event');
     });
 
     test('record() does not fail when no sender is configured', () async {

--- a/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/event_enrichment_client_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/event_enrichment_client_test.dart
@@ -9,12 +9,23 @@ class _MockSink implements EventSink {
   final List<EnrichedEvent> events = [];
 
   @override
-  void send(EnrichedEvent event) => events.add(event);
+  Future<void> send(EnrichedEvent event) async => events.add(event);
 }
 
+/// Throws synchronously, before returning a future at all.
 class _ThrowingSink implements EventSink {
   @override
-  void send(EnrichedEvent event) => throw StateError('sink failure');
+  Future<void> send(EnrichedEvent event) => throw StateError('sink failure');
+}
+
+/// Suspends first, then fails — the case a sync sink contract could not
+/// express and the try/catch in record() could not catch.
+class _AsyncFailingSink implements EventSink {
+  @override
+  Future<void> send(EnrichedEvent event) async {
+    await Future<void>.delayed(Duration.zero);
+    throw StateError('async sink failure');
+  }
 }
 
 void main() {
@@ -52,8 +63,8 @@ void main() {
       if (!client.isClosed) client.close();
     });
 
-    test('record() returns Ok with correct metadata', () {
-      final result = client.record('test_event');
+    test('record() returns Ok with correct metadata', () async {
+      final result = await client.record('test_event');
       expect(result, isA<Ok<EnrichedEvent>>());
       final event = (result as Ok<EnrichedEvent>).value;
       expect(event.eventType, 'test_event');
@@ -64,95 +75,100 @@ void main() {
       expect(event.session.id, isNotEmpty);
     });
 
-    test('record() dispatches to sink when configured', () {
-      client.record('test_event');
+    test('record() dispatches to sink when configured', () async {
+      await client.record('test_event');
       expect(sink.events, hasLength(1));
       expect(sink.events.first.eventType, 'test_event');
     });
 
-    test('record() does not fail when sink is null', () {
+    test('record() does not fail when sink is null', () async {
       final noSinkClient = EventEnrichmentClient(
         appMetadata: app,
         deviceMetadata: device,
         sdkMetadata: sdk,
         clientId: 'c',
       );
-      final result = noSinkClient.record('test');
+      final result = await noSinkClient.record('test');
       expect(result, isA<Ok<EnrichedEvent>>());
       noSinkClient.close();
     });
 
-    test('record() returns Error after close()', () {
+    test('record() returns Error after close()', () async {
       client.close();
-      final result = client.record('test');
+      final result = await client.record('test');
       expect(result, isA<Error<EnrichedEvent>>());
     });
 
-    test('per-event attributes override globals', () {
+    test('per-event attributes override globals', () async {
       client.addGlobalAttribute('key', 'global');
       final event =
-          (client.record('test', attributes: {'key': 'local'})
+          (await client.record('test', attributes: {'key': 'local'})
                   as Ok<EnrichedEvent>)
               .value;
       expect(event.attributes['key'], 'local');
     });
 
-    test('per-event metrics override globals', () {
+    test('per-event metrics override globals', () async {
       client.addGlobalMetric('m', 1);
       final event =
-          (client.record('test', metrics: {'m': 2.0}) as Ok<EnrichedEvent>)
+          (await client.record('test', metrics: {'m': 2.0})
+                  as Ok<EnrichedEvent>)
               .value;
       expect(event.metrics['m'], 2.0);
     });
 
-    test('global attributes appear on events', () {
+    test('global attributes appear on events', () async {
       client.addGlobalAttribute('env', 'prod');
-      final event = (client.record('test') as Ok<EnrichedEvent>).value;
+      final event = (await client.record('test') as Ok<EnrichedEvent>).value;
       expect(event.attributes['env'], 'prod');
     });
 
-    test('removed global attributes do not appear', () {
+    test('removed global attributes do not appear', () async {
       client
         ..addGlobalAttribute('env', 'prod')
         ..removeGlobalAttribute('env');
-      final event = (client.record('test') as Ok<EnrichedEvent>).value;
+      final event = (await client.record('test') as Ok<EnrichedEvent>).value;
       expect(event.attributes.containsKey('env'), isFalse);
     });
 
-    test('setUserId appears on subsequent events', () {
+    test('setUserId appears on subsequent events', () async {
       client.setUserId('user-1');
-      final event = (client.record('test') as Ok<EnrichedEvent>).value;
+      final event = (await client.record('test') as Ok<EnrichedEvent>).value;
       expect(event.userId, 'user-1');
     });
 
-    test('setUserId(null) clears userId', () {
+    test('setUserId(null) clears userId', () async {
       client
         ..setUserId('user-1')
         ..setUserId(null);
-      final event = (client.record('test') as Ok<EnrichedEvent>).value;
+      final event = (await client.record('test') as Ok<EnrichedEvent>).value;
       expect(event.userId, isNull);
     });
 
-    test('handleAppPaused and handleAppResumed maintain session', () {
-      final firstEvent = (client.record('before') as Ok<EnrichedEvent>).value;
+    test('handleAppPaused and handleAppResumed maintain session', () async {
+      final firstEvent =
+          (await client.record('before') as Ok<EnrichedEvent>).value;
       final sessionId = firstEvent.session.id;
 
       client
         ..handleAppPaused()
         ..handleAppResumed();
 
-      final secondEvent = (client.record('after') as Ok<EnrichedEvent>).value;
+      final secondEvent =
+          (await client.record('after') as Ok<EnrichedEvent>).value;
       expect(secondEvent.session.id, sessionId);
     });
 
-    test('record() after stopSession() starts a fresh session', () {
-      final firstEvent = (client.record('first') as Ok<EnrichedEvent>).value;
+    test('record() after stopSession() starts a fresh session', () async {
+      final firstEvent =
+          (await client.record('first') as Ok<EnrichedEvent>).value;
       final firstSessionId = firstEvent.session.id;
       expect(firstEvent.session.stopTimestamp, isNull);
 
       client.stopSession();
 
-      final secondEvent = (client.record('second') as Ok<EnrichedEvent>).value;
+      final secondEvent =
+          (await client.record('second') as Ok<EnrichedEvent>).value;
       expect(
         secondEvent.session.id,
         isNot(firstSessionId),
@@ -165,7 +181,7 @@ void main() {
       );
     });
 
-    test('record() surfaces a sink failure through Result.error', () {
+    test('record() surfaces a sink failure through Result.error', () async {
       final throwingClient = EventEnrichmentClient(
         appMetadata: app,
         deviceMetadata: device,
@@ -176,12 +192,38 @@ void main() {
       addTearDown(throwingClient.close);
 
       // Must return an Error result rather than throwing out of record().
-      final result = throwingClient.record('boom');
+      final result = await throwingClient.record('boom');
       expect(result, isA<Error<EnrichedEvent>>());
       expect(
         (result as Error<EnrichedEvent>).error,
         isA<EventEnrichmentRecordException>(),
       );
     });
+
+    test(
+      'record() catches a sink that fails asynchronously without propagating',
+      () async {
+        final failingClient = EventEnrichmentClient(
+          appMetadata: app,
+          deviceMetadata: device,
+          sdkMetadata: sdk,
+          clientId: 'device-123',
+          sink: _AsyncFailingSink(),
+        );
+        addTearDown(failingClient.close);
+
+        // The sink suspends before throwing, so this only passes because
+        // record() awaits send() inside its try/catch. Any error escaping to
+        // the zone would fail this test.
+        final result = await failingClient.record('boom');
+        expect(result, isA<Error<EnrichedEvent>>());
+        final error = (result as Error<EnrichedEvent>).error;
+        expect(error, isA<EventEnrichmentRecordException>());
+        expect(
+          (error as EventEnrichmentRecordException).cause,
+          isA<StateError>(),
+        );
+      },
+    );
   });
 }

--- a/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/event_enrichment_client_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/event_enrichment_client_test.dart
@@ -5,7 +5,7 @@ import 'package:amplify_event_enrichment_dart/amplify_event_enrichment.dart';
 import 'package:amplify_foundation_dart/amplify_foundation_dart.dart';
 import 'package:test/test.dart';
 
-class _MockSender implements Sender {
+class _MockSender implements EnrichedEventSender {
   final List<EnrichedEvent> events = [];
 
   @override
@@ -13,14 +13,14 @@ class _MockSender implements Sender {
 }
 
 /// Throws synchronously, before returning a future at all.
-class _ThrowingSender implements Sender {
+class _ThrowingSender implements EnrichedEventSender {
   @override
   Future<void> send(EnrichedEvent event) => throw StateError('sender failure');
 }
 
 /// Suspends first, then fails — the case a sync sender contract could not
 /// express and the try/catch in record() could not catch.
-class _AsyncFailingSender implements Sender {
+class _AsyncFailingSender implements EnrichedEventSender {
   @override
   Future<void> send(EnrichedEvent event) async {
     await Future<void>.delayed(Duration.zero);

--- a/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/event_enrichment_client_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/event_enrichment_client_test.dart
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import 'package:amplify_event_enrichment_dart/amplify_event_enrichment.dart';
+import 'package:amplify_event_enrichment_dart/amplify_event_enrichment_dart.dart';
 import 'package:amplify_foundation_dart/amplify_foundation_dart.dart';
 import 'package:test/test.dart';
 

--- a/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/event_enrichment_client_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/event_enrichment_client_test.dart
@@ -5,7 +5,7 @@ import 'package:amplify_event_enrichment_dart/amplify_event_enrichment.dart';
 import 'package:amplify_foundation_dart/amplify_foundation_dart.dart';
 import 'package:test/test.dart';
 
-class _MockSink implements EventSink {
+class _MockSender implements Sender {
   final List<EnrichedEvent> events = [];
 
   @override
@@ -13,25 +13,25 @@ class _MockSink implements EventSink {
 }
 
 /// Throws synchronously, before returning a future at all.
-class _ThrowingSink implements EventSink {
+class _ThrowingSender implements Sender {
   @override
-  Future<void> send(EnrichedEvent event) => throw StateError('sink failure');
+  Future<void> send(EnrichedEvent event) => throw StateError('sender failure');
 }
 
-/// Suspends first, then fails — the case a sync sink contract could not
+/// Suspends first, then fails — the case a sync sender contract could not
 /// express and the try/catch in record() could not catch.
-class _AsyncFailingSink implements EventSink {
+class _AsyncFailingSender implements Sender {
   @override
   Future<void> send(EnrichedEvent event) async {
     await Future<void>.delayed(Duration.zero);
-    throw StateError('async sink failure');
+    throw StateError('async sender failure');
   }
 }
 
 void main() {
   group('EventEnrichmentClient', () {
     late EventEnrichmentClient client;
-    late _MockSink sink;
+    late _MockSender sender;
 
     const app = AppMetadata(
       appId: 'testApp1',
@@ -49,13 +49,13 @@ void main() {
     const sdk = SdkMetadata(name: 'amplify-flutter', version: '2.0.0');
 
     setUp(() {
-      sink = _MockSink();
+      sender = _MockSender();
       client = EventEnrichmentClient(
         appMetadata: app,
         deviceMetadata: device,
         sdkMetadata: sdk,
         clientId: 'device-123',
-        sink: sink,
+        sender: sender,
       );
     });
 
@@ -75,22 +75,22 @@ void main() {
       expect(event.session.id, isNotEmpty);
     });
 
-    test('record() dispatches to sink when configured', () async {
+    test('record() dispatches to the sender when configured', () async {
       await client.record('test_event');
-      expect(sink.events, hasLength(1));
-      expect(sink.events.first.eventType, 'test_event');
+      expect(sender.events, hasLength(1));
+      expect(sender.events.first.eventType, 'test_event');
     });
 
-    test('record() does not fail when sink is null', () async {
-      final noSinkClient = EventEnrichmentClient(
+    test('record() does not fail when no sender is configured', () async {
+      final noSenderClient = EventEnrichmentClient(
         appMetadata: app,
         deviceMetadata: device,
         sdkMetadata: sdk,
         clientId: 'c',
       );
-      final result = await noSinkClient.record('test');
+      final result = await noSenderClient.record('test');
       expect(result, isA<Ok<EnrichedEvent>>());
-      noSinkClient.close();
+      noSenderClient.close();
     });
 
     test('record() returns Error after close()', () async {
@@ -181,13 +181,48 @@ void main() {
       );
     });
 
-    test('record() surfaces a sink failure through Result.error', () async {
+    test(
+      'handleAppResumed does not restart a session stopped explicitly',
+      () async {
+        await client.record('first');
+        final stopped = client.sessionManager.session!;
+
+        client
+          ..stopSession()
+          ..handleAppResumed();
+
+        expect(client.sessionManager.state, SessionState.stopped);
+        expect(client.sessionManager.session!.id, stopped.id);
+      },
+    );
+
+    test('record() still starts a session after an explicit stop', () async {
+      // The lazy start in record() is deliberately unaffected by the explicit
+      // stop flag: recording an event always produces one with a session.
+      client.stopSession();
+      final result = await client.record('after_stop');
+      expect(result, isA<Ok<EnrichedEvent>>());
+      expect(client.sessionManager.state, SessionState.active);
+      expect((result as Ok<EnrichedEvent>).value.session.stopTimestamp, isNull);
+    });
+
+    test('close() drops the session and blocks lifecycle restarts', () async {
+      await client.record('before_close');
+      client
+        ..close()
+        ..handleAppResumed();
+
+      expect(client.sessionManager.session, isNull);
+      expect(client.sessionManager.state, SessionState.stopped);
+    });
+
+    test('record() surfaces a sender failure through Result.error', () async {
       final throwingClient = EventEnrichmentClient(
         appMetadata: app,
         deviceMetadata: device,
         sdkMetadata: sdk,
         clientId: 'device-123',
-        sink: _ThrowingSink(),
+        sender: _ThrowingSender(),
       );
       addTearDown(throwingClient.close);
 
@@ -201,18 +236,18 @@ void main() {
     });
 
     test(
-      'record() catches a sink that fails asynchronously without propagating',
+      'record() catches a sender that fails asynchronously without propagating',
       () async {
         final failingClient = EventEnrichmentClient(
           appMetadata: app,
           deviceMetadata: device,
           sdkMetadata: sdk,
           clientId: 'device-123',
-          sink: _AsyncFailingSink(),
+          sender: _AsyncFailingSender(),
         );
         addTearDown(failingClient.close);
 
-        // The sink suspends before throwing, so this only passes because
+        // The sender suspends before throwing, so this only passes because
         // record() awaits send() inside its try/catch. Any error escaping to
         // the zone would fail this test.
         final result = await failingClient.record('boom');

--- a/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/event_enrichment_client_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/event_enrichment_client_test.dart
@@ -100,6 +100,10 @@ void main() {
       await client.close();
       final result = await client.record('test');
       expect(result, isA<Error<EnrichedEvent>>());
+      expect(
+        (result as Error<EnrichedEvent>).error,
+        isA<EventEnrichmentClosedException>(),
+      );
     });
 
     test('per-event attributes override globals', () async {

--- a/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/global_fields_manager_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/global_fields_manager_test.dart
@@ -1,0 +1,69 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_event_enrichment_dart/src/global_fields_manager.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('GlobalFieldsManager', () {
+    late GlobalFieldsManager manager;
+
+    setUp(() {
+      manager = GlobalFieldsManager();
+    });
+
+    test('starts empty', () {
+      expect(manager.attributes, isEmpty);
+      expect(manager.metrics, isEmpty);
+    });
+
+    test('addAttribute stores value', () {
+      manager.addAttribute('key1', 'value1');
+      expect(manager.attributes['key1'], 'value1');
+    });
+
+    test('addAttribute overwrites existing key', () {
+      manager.addAttribute('key1', 'value1');
+      manager.addAttribute('key1', 'value2');
+      expect(manager.attributes['key1'], 'value2');
+    });
+
+    test('removeAttribute removes key', () {
+      manager.addAttribute('key1', 'value1');
+      manager.removeAttribute('key1');
+      expect(manager.attributes, isEmpty);
+    });
+
+    test('removeAttribute is no-op for missing key', () {
+      manager.removeAttribute('nonexistent');
+      expect(manager.attributes, isEmpty);
+    });
+
+    test('addMetric stores value', () {
+      manager.addMetric('metric1', 3.14);
+      expect(manager.metrics['metric1'], 3.14);
+    });
+
+    test('removeMetric removes key', () {
+      manager.addMetric('metric1', 1.0);
+      manager.removeMetric('metric1');
+      expect(manager.metrics, isEmpty);
+    });
+
+    test('attributes view is unmodifiable', () {
+      manager.addAttribute('key', 'val');
+      expect(
+        () => manager.attributes['new'] = 'fail',
+        throwsA(isA<UnsupportedError>()),
+      );
+    });
+
+    test('metrics view is unmodifiable', () {
+      manager.addMetric('key', 1.0);
+      expect(
+        () => manager.metrics['new'] = 2.0,
+        throwsA(isA<UnsupportedError>()),
+      );
+    });
+  });
+}

--- a/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/global_fields_manager_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/global_fields_manager_test.dart
@@ -23,14 +23,16 @@ void main() {
     });
 
     test('addAttribute overwrites existing key', () {
-      manager.addAttribute('key1', 'value1');
-      manager.addAttribute('key1', 'value2');
+      manager
+        ..addAttribute('key1', 'value1')
+        ..addAttribute('key1', 'value2');
       expect(manager.attributes['key1'], 'value2');
     });
 
     test('removeAttribute removes key', () {
-      manager.addAttribute('key1', 'value1');
-      manager.removeAttribute('key1');
+      manager
+        ..addAttribute('key1', 'value1')
+        ..removeAttribute('key1');
       expect(manager.attributes, isEmpty);
     });
 
@@ -45,8 +47,9 @@ void main() {
     });
 
     test('removeMetric removes key', () {
-      manager.addMetric('metric1', 1.0);
-      manager.removeMetric('metric1');
+      manager
+        ..addMetric('metric1', 1)
+        ..removeMetric('metric1');
       expect(manager.metrics, isEmpty);
     });
 
@@ -59,7 +62,7 @@ void main() {
     });
 
     test('metrics view is unmodifiable', () {
-      manager.addMetric('key', 1.0);
+      manager.addMetric('key', 1);
       expect(
         () => manager.metrics['new'] = 2.0,
         throwsA(isA<UnsupportedError>()),

--- a/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/session_event_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/session_event_test.dart
@@ -1,10 +1,25 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import 'dart:async';
+
 import 'package:amplify_event_enrichment_dart/amplify_event_enrichment_dart.dart';
 import 'package:amplify_foundation_dart/amplify_foundation_dart.dart';
 import 'package:fake_async/fake_async.dart';
 import 'package:test/test.dart';
+
+/// A timer that never runs its callback, standing in for iOS suspending the
+/// Dart event loop while the app is backgrounded.
+class _NeverFiringTimer implements Timer {
+  @override
+  void cancel() {}
+
+  @override
+  bool get isActive => true;
+
+  @override
+  int get tick => 0;
+}
 
 class _RecordingSender implements EnrichedEventSender {
   final List<EnrichedEvent> events = [];
@@ -638,6 +653,84 @@ void main() {
 
         expect(initialSender.sessionStarts.single.userId, 'user-1');
         expect(initialSender.events.last.userId, 'user-2');
+      });
+    });
+
+    group('recording during a pause', () {
+      /// A client whose pause timer never fires, so only the elapsed-time
+      /// comparison can tell the session expired.
+      EventEnrichmentClient suspendedTimerClient(EnrichedEventSender sender) {
+        final built = buildClient(sender);
+        // Armed on pause, which has not happened yet, so replacing the factory
+        // after construction still covers every timer this client arms.
+        built.sessionManager.timerFactory = (_, _) => _NeverFiringTimer();
+        return built;
+      }
+
+      test('past the timeout, the dead session is replaced first', () {
+        fakeAsync((async) {
+          final pausedSender = _RecordingSender();
+          final pausedClient = suspendedTimerClient(pausedSender);
+          final first = pausedClient.sessionManager.session!;
+          async.flushMicrotasks();
+
+          pausedClient.handleAppPaused();
+          async.elapse(const Duration(minutes: 20));
+          pausedClient.record('button_clicked');
+          async.flushMicrotasks();
+
+          expect(pausedSender.types, [
+            zSessionStartEventType,
+            zSessionStopEventType,
+            zSessionStartEventType,
+            'button_clicked',
+          ], reason: 'the expired session must be closed out before the event');
+          expect(pausedSender.sessionStops.single.session.id, first.id);
+          expect(
+            pausedSender.events.last.session.id,
+            isNot(first.id),
+            reason: 'the event belongs to the session that is live now, not to '
+                'one that ended 20 minutes ago',
+          );
+          expect(
+            pausedSender.events.last.session.id,
+            pausedClient.sessionManager.session!.id,
+          );
+        });
+      });
+
+      test('the replacement stays paused, since the app still is', () {
+        fakeAsync((async) {
+          final pausedSender = _RecordingSender();
+          final pausedClient = suspendedTimerClient(pausedSender)
+            ..handleAppPaused();
+          async.elapse(const Duration(minutes: 20));
+          pausedClient.record('button_clicked');
+          async.flushMicrotasks();
+
+          expect(pausedClient.sessionManager.state, SessionState.paused);
+        });
+      });
+
+      test('inside the timeout, the same session is used silently', () {
+        fakeAsync((async) {
+          final pausedSender = _RecordingSender();
+          final pausedClient = suspendedTimerClient(pausedSender);
+          final first = pausedClient.sessionManager.session!;
+          async.flushMicrotasks();
+
+          pausedClient.handleAppPaused();
+          async.elapse(const Duration(seconds: 3));
+          pausedClient.record('button_clicked');
+          async.flushMicrotasks();
+
+          expect(pausedSender.types, [
+            zSessionStartEventType,
+            'button_clicked',
+          ], reason: 'still the same session, so no boundary');
+          expect(pausedSender.events.last.session.id, first.id);
+          expect(pausedClient.sessionManager.state, SessionState.paused);
+        });
       });
     });
 

--- a/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/session_event_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/session_event_test.dart
@@ -12,10 +12,37 @@ class _RecordingSender implements Sender {
   @override
   Future<void> send(EnrichedEvent event) async => events.add(event);
 
-  /// Only the session-stop events, so counts are unaffected by whatever the
-  /// test recorded to get a session started.
+  /// Only the session-boundary events, so counts and ordering are unaffected by
+  /// whatever the test recorded to move a session along.
+  List<EnrichedEvent> get sessionEvents => events
+      .where(
+        (e) =>
+            e.eventType == zSessionStartEventType ||
+            e.eventType == zSessionStopEventType,
+      )
+      .toList();
+
+  List<EnrichedEvent> get sessionStarts =>
+      events.where((e) => e.eventType == zSessionStartEventType).toList();
+
   List<EnrichedEvent> get sessionStops =>
       events.where((e) => e.eventType == zSessionStopEventType).toList();
+
+  List<String> get types => events.map((e) => e.eventType).toList();
+}
+
+/// Records when each send begins and completes, so a test can tell an ordered
+/// hand-off from two sends that are in flight at the same time. A sender that
+/// appends synchronously cannot see the difference.
+class _InterleavingSender implements Sender {
+  final List<String> log = [];
+
+  @override
+  Future<void> send(EnrichedEvent event) async {
+    log.add('${event.eventType} begin');
+    await Future<void>.delayed(Duration.zero);
+    log.add('${event.eventType} end');
+  }
 }
 
 /// Fails after suspending — the case a synchronous throw does not cover, and
@@ -33,7 +60,7 @@ class _AsyncFailingSender implements Sender {
 }
 
 void main() {
-  group('session stop event emission', () {
+  group('session event emission', () {
     const app = AppMetadata(
       appId: 'testApp1',
       packageName: 'com.example',
@@ -73,7 +100,204 @@ void main() {
       client = buildClient(sender);
     });
 
-    group('emits', () {
+    group('emits a start', () {
+      test('at construction when autoSessionTracking is on', () async {
+        // The client under test is built in setUp, so the start is already out.
+        await pumpEventQueue();
+
+        expect(sender.sessionStarts, hasLength(1));
+        final event = sender.sessionStarts.single;
+        expect(event.eventType, '_session.start');
+        expect(event.session.id, client.sessionManager.session!.id);
+        expect(event.session.startTimestamp, isNotEmpty);
+        expect(
+          event.session.stopTimestamp,
+          isNull,
+          reason: 'a session that just started has not stopped',
+        );
+        expect(event.session.duration, isNull);
+      });
+
+      test('ahead of an event recorded straight after construction', () async {
+        // The eager start has no caller to await it, so this only holds
+        // because a start with nothing to displace is reported synchronously.
+        final eagerSender = _RecordingSender();
+        final eagerClient = buildClient(eagerSender);
+        await eagerClient.record('first');
+
+        expect(eagerSender.types, [zSessionStartEventType, 'first']);
+        await eagerClient.close();
+      });
+
+      test('with the same enrichment a recorded event gets', () async {
+        final enrichedSender = _RecordingSender();
+        final enrichedClient =
+            buildClient(enrichedSender, autoSessionTracking: false)
+              ..setUserId('user-1')
+              ..addGlobalAttribute('env', 'prod')
+              ..addGlobalMetric('score', 4.5);
+        addTearDown(enrichedClient.close);
+
+        await enrichedClient.startSession();
+
+        final event = enrichedSender.sessionStarts.single;
+        expect(event.app.appId, 'testApp1');
+        expect(event.device.platform, 'iOS');
+        expect(event.sdk.name, 'amplify-flutter');
+        expect(event.clientId, 'device-123');
+        expect(event.userId, 'user-1');
+        expect(event.eventId, isNotEmpty);
+        // Pinpoint stamped its globals on _session.start too.
+        expect(event.attributes['env'], 'prod');
+        expect(event.metrics['score'], 4.5);
+      });
+
+      test('on an explicit startSession(), after the displaced stop', () async {
+        final displaced = client.sessionManager.session!;
+
+        await client.startSession();
+
+        // Pinpoint stopped the running session before starting its
+        // replacement, so the pair must arrive in that order.
+        expect(sender.sessionEvents.map((e) => e.eventType), [
+          zSessionStartEventType,
+          zSessionStopEventType,
+          zSessionStartEventType,
+        ]);
+        expect(sender.sessionStops.single.session.id, displaced.id);
+        expect(sender.sessionStarts.last.session.id, isNot(displaced.id));
+        expect(
+          sender.sessionStarts.last.session.id,
+          client.sessionManager.session!.id,
+        );
+      });
+
+      test("on record()'s lazy start, before the recorded event", () async {
+        final lazySender = _RecordingSender();
+        final lazyClient = buildClient(lazySender, autoSessionTracking: false);
+        addTearDown(lazyClient.close);
+
+        await lazyClient.record('first');
+
+        expect(lazySender.types, [zSessionStartEventType, 'first']);
+        expect(
+          lazySender.sessionStarts.single.session.id,
+          lazyClient.sessionManager.session!.id,
+        );
+      });
+
+      test('when a resume follows a session timeout', () {
+        fakeAsync((async) {
+          final cycleSender = _RecordingSender();
+          final cycleClient = buildClient(cycleSender);
+          final first = cycleClient.sessionManager.session!;
+
+          cycleClient.handleAppPaused();
+          async
+            ..elapse(timeout)
+            ..flushMicrotasks();
+          cycleClient.handleAppResumed();
+          async.flushMicrotasks();
+
+          final second = cycleClient.sessionManager.session!;
+          expect(second.id, isNot(first.id));
+          expect(cycleSender.sessionStarts, hasLength(2));
+          expect(cycleSender.sessionStarts.last.session.id, second.id);
+        });
+      });
+    });
+
+    group('ordering', () {
+      test('a displaced stop completes before the new start begins', () async {
+        final seq = _InterleavingSender();
+        final seqClient = buildClient(seq, autoSessionTracking: false);
+        addTearDown(seqClient.close);
+
+        await seqClient.startSession();
+        seq.log.clear();
+
+        await seqClient.startSession();
+
+        // Interleaved begins would mean two sends in flight at once. The stop
+        // must be fully handed off before the start that replaced it starts.
+        expect(seq.log, [
+          '$zSessionStopEventType begin',
+          '$zSessionStopEventType end',
+          '$zSessionStartEventType begin',
+          '$zSessionStartEventType end',
+        ]);
+      });
+
+      test("a lazy start completes before record()'s own send", () async {
+        final seq = _InterleavingSender();
+        final seqClient = buildClient(seq, autoSessionTracking: false);
+        addTearDown(seqClient.close);
+
+        await seqClient.record('first');
+
+        expect(seq.log, [
+          '$zSessionStartEventType begin',
+          '$zSessionStartEventType end',
+          'first begin',
+          'first end',
+        ]);
+      });
+    });
+
+    group('does not emit a start', () {
+      test('at construction when autoSessionTracking is off', () async {
+        final idleSender = _RecordingSender();
+        final idle = buildClient(idleSender, autoSessionTracking: false);
+        await pumpEventQueue();
+
+        expect(idleSender.sessionEvents, isEmpty);
+        await idle.close();
+      });
+
+      test('when a pause and resume stay within the timeout', () {
+        fakeAsync((async) {
+          final pauseSender = _RecordingSender();
+          final pauseClient = buildClient(pauseSender);
+          final started = pauseClient.sessionManager.session!;
+          async.flushMicrotasks();
+
+          pauseClient.handleAppPaused();
+          async.elapse(const Duration(seconds: 3));
+          pauseClient.handleAppResumed();
+          async.flushMicrotasks();
+
+          expect(
+            pauseSender.sessionStarts,
+            hasLength(1),
+            reason: 'still the same session, so no new boundary',
+          );
+          expect(pauseSender.sessionStops, isEmpty);
+          expect(pauseClient.sessionManager.session!.id, started.id);
+        });
+      });
+
+      test('when a resume follows an explicit stop', () async {
+        await client.stopSession();
+        client.handleAppResumed();
+        await pumpEventQueue();
+
+        expect(sender.sessionStarts, hasLength(1));
+        expect(client.sessionManager.state, SessionState.stopped);
+      });
+
+      test('for a stop, a close, or a cleared session', () async {
+        await client.stopSession();
+        await client.close();
+
+        expect(
+          sender.sessionStarts,
+          hasLength(1),
+          reason: 'only the construction start; ending never starts anything',
+        );
+      });
+    });
+
+    group('emits a stop', () {
       test(
         'on an explicit stopSession(), carrying the stopped session',
         () async {
@@ -172,7 +396,7 @@ void main() {
       });
     });
 
-    group('does not emit', () {
+    group('does not emit a stop', () {
       test('when no session was ever started', () async {
         final idle = buildClient(sender, autoSessionTracking: false);
         expect(idle.sessionManager.session, isNull);
@@ -235,22 +459,6 @@ void main() {
         await idle.close();
       });
 
-      test('when a pause and resume stay within the timeout', () {
-        fakeAsync((async) {
-          final pauseSender = _RecordingSender();
-          final pauseClient = buildClient(pauseSender);
-          final started = pauseClient.sessionManager.session!;
-
-          pauseClient.handleAppPaused();
-          async.elapse(const Duration(seconds: 3));
-          pauseClient.handleAppResumed();
-          async.flushMicrotasks();
-
-          expect(pauseSender.sessionStops, isEmpty);
-          expect(pauseClient.sessionManager.session!.id, started.id);
-        });
-      });
-
       test('again when handleAppResumed follows an explicit stop', () async {
         await client.stopSession();
         client.handleAppResumed();
@@ -306,9 +514,11 @@ void main() {
             hasLength(1),
             reason: 'the lazy start displaces nothing, so it ends nothing',
           );
-          expect(sender.events.map((e) => e.eventType), [
+          expect(sender.types, [
+            zSessionStartEventType,
             'first',
             zSessionStopEventType,
+            zSessionStartEventType,
             'second',
           ]);
         },
@@ -316,41 +526,67 @@ void main() {
     });
 
     test('each session is reported exactly once across a timeout cycle', () {
-      // Two sessions live and die here, so two stops — one per session, and
-      // never two for the same one.
+      // Two sessions live and die here, so two starts and two stops, one pair
+      // per session, interleaved and never doubled.
       fakeAsync((async) {
         final cycleSender = _RecordingSender();
         final cycleClient = buildClient(cycleSender);
         final first = cycleClient.sessionManager.session!;
+        async.flushMicrotasks();
 
         cycleClient.handleAppPaused();
         async
           ..elapse(timeout)
           ..flushMicrotasks();
         cycleClient.handleAppResumed();
+        async.flushMicrotasks();
         final second = cycleClient.sessionManager.session!;
         expect(second.id, isNot(first.id));
 
         cycleClient.stopSession();
         async.flushMicrotasks();
 
-        expect(cycleSender.sessionStops.map((e) => e.session.id), [
+        expect(cycleSender.sessionEvents.map((e) => e.eventType), [
+          zSessionStartEventType,
+          zSessionStopEventType,
+          zSessionStartEventType,
+          zSessionStopEventType,
+        ]);
+        expect(cycleSender.sessionEvents.map((e) => e.session.id), [
           first.id,
+          first.id,
+          second.id,
           second.id,
         ]);
       });
     });
 
     group('sender failures', () {
-      test('are logged rather than thrown out of stopSession()', () async {
+      test('are logged rather than thrown out of startSession()', () async {
         final failing = _AsyncFailingSender();
-        final failingClient = buildClient(failing);
+        final failingClient = buildClient(failing, autoSessionTracking: false);
 
         // The sender suspends before failing, so this only passes because the
         // emission awaits send() inside its own guard. An error escaping to
         // the zone fails this test.
+        await expectLater(failingClient.startSession(), completes);
+        expect(failing.sendCount, 1, reason: 'the start was attempted');
+        expect(failingClient.sessionManager.state, SessionState.active);
+
+        await expectLater(failingClient.close(), completes);
+      });
+
+      test('are logged rather than thrown out of stopSession()', () async {
+        final failing = _AsyncFailingSender();
+        final failingClient = buildClient(failing, autoSessionTracking: false);
+
+        await expectLater(failingClient.startSession(), completes);
         await expectLater(failingClient.stopSession(), completes);
-        expect(failing.sendCount, 1);
+        expect(
+          failing.sendCount,
+          2,
+          reason: 'both the start and the stop were attempted and both failed',
+        );
         expect(failingClient.sessionManager.state, SessionState.stopped);
 
         await expectLater(failingClient.close(), completes);
@@ -361,7 +597,11 @@ void main() {
         final failingClient = buildClient(failing);
 
         await expectLater(failingClient.close(), completes);
-        expect(failing.sendCount, 1);
+        expect(
+          failing.sendCount,
+          2,
+          reason: "the construction start and close's stop both failed",
+        );
         expect(failingClient.isClosed, isTrue);
       });
 
@@ -382,7 +622,7 @@ void main() {
       });
     });
 
-    test('no session stop event is emitted without a sender', () async {
+    test('no session event is emitted without a sender', () async {
       final senderless = EventEnrichmentClient(
         appMetadata: app,
         deviceMetadata: device,
@@ -392,6 +632,7 @@ void main() {
 
       // Nothing to assert on but the absence of a throw: the emission path is
       // a no-op with no sender configured.
+      await expectLater(senderless.startSession(), completes);
       await expectLater(senderless.stopSession(), completes);
       await expectLater(senderless.close(), completes);
     });

--- a/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/session_event_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/session_event_test.dart
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import 'package:amplify_event_enrichment_dart/amplify_event_enrichment.dart';
+import 'package:amplify_event_enrichment_dart/amplify_event_enrichment_dart.dart';
 import 'package:amplify_foundation_dart/amplify_foundation_dart.dart';
 import 'package:fake_async/fake_async.dart';
 import 'package:test/test.dart';

--- a/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/session_event_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/session_event_test.dart
@@ -561,6 +561,86 @@ void main() {
       });
     });
 
+    group('the launch start carries the initial fields', () {
+      test('when they are passed to the constructor', () async {
+        // The whole point of the parameters: the eager start emits from the
+        // constructor, so setUserId and addGlobalAttribute cannot reach it.
+        final initialSender = _RecordingSender();
+        final initialClient = EventEnrichmentClient(
+          appMetadata: app,
+          deviceMetadata: device,
+          sdkMetadata: sdk,
+          clientId: 'device-123',
+          initialUserId: 'user-1',
+          initialGlobalAttributes: const {'env': 'prod'},
+          initialGlobalMetrics: const {'score': 4.5},
+          sender: initialSender,
+          options: const EventEnrichmentClientOptions(sessionTimeout: timeout),
+        );
+        addTearDown(initialClient.close);
+        await pumpEventQueue();
+
+        final event = initialSender.sessionStarts.single;
+        expect(event.userId, 'user-1');
+        expect(event.attributes['env'], 'prod');
+        expect(event.metrics['score'], 4.5);
+      });
+
+      test('and nothing when they are not', () async {
+        // client comes from setUp, which passes none of them.
+        await pumpEventQueue();
+
+        final event = sender.sessionStarts.single;
+        expect(event.userId, isNull);
+        expect(event.attributes, isEmpty);
+        expect(event.metrics, isEmpty);
+      });
+
+      test('and they keep applying to later events', () async {
+        final initialSender = _RecordingSender();
+        final initialClient = EventEnrichmentClient(
+          appMetadata: app,
+          deviceMetadata: device,
+          sdkMetadata: sdk,
+          clientId: 'device-123',
+          initialUserId: 'user-1',
+          initialGlobalAttributes: const {'env': 'prod'},
+          sender: initialSender,
+          options: const EventEnrichmentClientOptions(sessionTimeout: timeout),
+        );
+        addTearDown(initialClient.close);
+
+        await initialClient.record('button_clicked');
+
+        final recorded = initialSender.events.last;
+        expect(recorded.eventType, 'button_clicked');
+        expect(recorded.userId, 'user-1');
+        expect(recorded.attributes['env'], 'prod');
+      });
+
+      test('and setUserId still overrides afterwards', () async {
+        final initialSender = _RecordingSender();
+        final initialClient =
+            EventEnrichmentClient(
+              appMetadata: app,
+              deviceMetadata: device,
+              sdkMetadata: sdk,
+              clientId: 'device-123',
+              initialUserId: 'user-1',
+              sender: initialSender,
+              options: const EventEnrichmentClientOptions(
+                sessionTimeout: timeout,
+              ),
+            )..setUserId('user-2');
+        addTearDown(initialClient.close);
+
+        await initialClient.record('button_clicked');
+
+        expect(initialSender.sessionStarts.single.userId, 'user-1');
+        expect(initialSender.events.last.userId, 'user-2');
+      });
+    });
+
     group('sender failures', () {
       test('are logged rather than thrown out of startSession()', () async {
         final failing = _AsyncFailingSender();

--- a/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/session_event_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/session_event_test.dart
@@ -6,7 +6,7 @@ import 'package:amplify_foundation_dart/amplify_foundation_dart.dart';
 import 'package:fake_async/fake_async.dart';
 import 'package:test/test.dart';
 
-class _RecordingSender implements Sender {
+class _RecordingSender implements EnrichedEventSender {
   final List<EnrichedEvent> events = [];
 
   @override
@@ -34,7 +34,7 @@ class _RecordingSender implements Sender {
 /// Records when each send begins and completes, so a test can tell an ordered
 /// hand-off from two sends that are in flight at the same time. A sender that
 /// appends synchronously cannot see the difference.
-class _InterleavingSender implements Sender {
+class _InterleavingSender implements EnrichedEventSender {
   final List<String> log = [];
 
   @override
@@ -48,7 +48,7 @@ class _InterleavingSender implements Sender {
 /// Fails after suspending — the case a synchronous throw does not cover, and
 /// the one that escapes as an unhandled async error if the emission is not
 /// awaited inside its own guard.
-class _AsyncFailingSender implements Sender {
+class _AsyncFailingSender implements EnrichedEventSender {
   int sendCount = 0;
 
   @override
@@ -78,7 +78,7 @@ void main() {
     const timeout = Duration(seconds: 5);
 
     EventEnrichmentClient buildClient(
-      Sender sender, {
+      EnrichedEventSender sender, {
       bool autoSessionTracking = true,
     }) => EventEnrichmentClient(
       appMetadata: app,

--- a/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/session_event_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/session_event_test.dart
@@ -257,6 +257,36 @@ void main() {
           'first end',
         ]);
       });
+
+      test('a second close() waits for the same teardown', () async {
+        final seq = _InterleavingSender();
+        final seqClient = buildClient(seq, autoSessionTracking: false);
+        await seqClient.startSession();
+        seq.log.clear();
+
+        final first = seqClient.close();
+        expect(
+          seqClient.isClosed,
+          isTrue,
+          reason: 'closed from the first call',
+        );
+        final second = seqClient.close();
+        await second;
+
+        // The second caller gets the first call's future, so it cannot
+        // complete while the final stop is still in flight.
+        expect(seq.log, [
+          '$zSessionStopEventType begin',
+          '$zSessionStopEventType end',
+        ]);
+
+        await first;
+        expect(
+          seq.log,
+          hasLength(2),
+          reason: 'the teardown ran once, so there is only one stop',
+        );
+      });
     });
 
     group('does not emit a start', () {
@@ -635,18 +665,15 @@ void main() {
 
       test('and setUserId still overrides afterwards', () async {
         final initialSender = _RecordingSender();
-        final initialClient =
-            EventEnrichmentClient(
-              appMetadata: app,
-              deviceMetadata: device,
-              sdkMetadata: sdk,
-              clientId: 'device-123',
-              initialUserId: 'user-1',
-              sender: initialSender,
-              options: const EventEnrichmentClientOptions(
-                sessionTimeout: timeout,
-              ),
-            )..setUserId('user-2');
+        final initialClient = EventEnrichmentClient(
+          appMetadata: app,
+          deviceMetadata: device,
+          sdkMetadata: sdk,
+          clientId: 'device-123',
+          initialUserId: 'user-1',
+          sender: initialSender,
+          options: const EventEnrichmentClientOptions(sessionTimeout: timeout),
+        )..setUserId('user-2');
         addTearDown(initialClient.close);
 
         await initialClient.record('button_clicked');
@@ -689,7 +716,8 @@ void main() {
           expect(
             pausedSender.events.last.session.id,
             isNot(first.id),
-            reason: 'the event belongs to the session that is live now, not to '
+            reason:
+                'the event belongs to the session that is live now, not to '
                 'one that ended 20 minutes ago',
           );
           expect(

--- a/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/session_manager_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/session_manager_test.dart
@@ -32,18 +32,21 @@ void main() {
       expect(manager.session!.id, contains('testApp1'));
     });
 
-    test('session ID follows format: appId(8)-uniqueId(8)-yyyyMMdd-HHmmssSSS',
-        () {
-      manager.startSession();
-      final id = manager.session!.id;
-      expect(id.startsWith('testApp1-'), isTrue);
-      final afterPrefix = id.substring(9);
-      expect(afterPrefix.startsWith('abcd0000'), isTrue);
-    });
+    test(
+      'session ID follows format: appId(8)-uniqueId(8)-yyyyMMdd-HHmmssSSS',
+      () {
+        manager.startSession();
+        final id = manager.session!.id;
+        expect(id.startsWith('testApp1-'), isTrue);
+        final afterPrefix = id.substring(9);
+        expect(afterPrefix.startsWith('abcd0000'), isTrue);
+      },
+    );
 
     test('stopSession transitions to stopped with duration', () {
-      manager.startSession();
-      manager.stopSession();
+      manager
+        ..startSession()
+        ..stopSession();
       expect(manager.state, SessionState.stopped);
       expect(manager.session!.stopTimestamp, isNotNull);
       expect(manager.session!.duration, isNotNull);
@@ -51,8 +54,9 @@ void main() {
 
     test('handleAppPaused transitions active to paused', () {
       fakeAsync((async) {
-        manager.startSession();
-        manager.handleAppPaused();
+        manager
+          ..startSession()
+          ..handleAppPaused();
         expect(manager.state, SessionState.paused);
       });
     });
@@ -71,8 +75,9 @@ void main() {
 
     test('timeout expiry stops session', () {
       fakeAsync((async) {
-        manager.startSession();
-        manager.handleAppPaused();
+        manager
+          ..startSession()
+          ..handleAppPaused();
         async.elapse(timeout);
         expect(manager.state, SessionState.stopped);
         expect(manager.session!.stopTimestamp, isNotNull);
@@ -108,8 +113,7 @@ void main() {
         appId: 'ab',
         sessionTimeout: timeout,
         generateId: () => 'uuid0000-fake-uuid-value',
-      );
-      shortManager.startSession();
+      )..startSession();
       final id = shortManager.session!.id;
       expect(id.substring(0, 8), '______ab');
     });

--- a/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/session_manager_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/session_manager_test.dart
@@ -1,0 +1,117 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_event_enrichment_dart/src/session/session_manager.dart';
+import 'package:fake_async/fake_async.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SessionManager', () {
+    late SessionManager manager;
+    const timeout = Duration(seconds: 5);
+    var idCounter = 0;
+
+    setUp(() {
+      idCounter = 0;
+      manager = SessionManager(
+        appId: 'testApp1',
+        sessionTimeout: timeout,
+        generateId: () => 'abcd${idCounter++}000-fake-uuid-value',
+      );
+    });
+
+    test('starts in stopped state with no session', () {
+      expect(manager.state, SessionState.stopped);
+      expect(manager.session, isNull);
+    });
+
+    test('startSession transitions to active', () {
+      manager.startSession();
+      expect(manager.state, SessionState.active);
+      expect(manager.session, isNotNull);
+      expect(manager.session!.id, contains('testApp1'));
+    });
+
+    test('session ID follows format: appId(8)-uniqueId(8)-yyyyMMdd-HHmmssSSS',
+        () {
+      manager.startSession();
+      final id = manager.session!.id;
+      expect(id.startsWith('testApp1-'), isTrue);
+      final afterPrefix = id.substring(9);
+      expect(afterPrefix.startsWith('abcd0000'), isTrue);
+    });
+
+    test('stopSession transitions to stopped with duration', () {
+      manager.startSession();
+      manager.stopSession();
+      expect(manager.state, SessionState.stopped);
+      expect(manager.session!.stopTimestamp, isNotNull);
+      expect(manager.session!.duration, isNotNull);
+    });
+
+    test('handleAppPaused transitions active to paused', () {
+      fakeAsync((async) {
+        manager.startSession();
+        manager.handleAppPaused();
+        expect(manager.state, SessionState.paused);
+      });
+    });
+
+    test('handleAppResumed within timeout resumes same session', () {
+      fakeAsync((async) {
+        manager.startSession();
+        final sessionId = manager.session!.id;
+        manager.handleAppPaused();
+        async.elapse(const Duration(seconds: 3));
+        manager.handleAppResumed();
+        expect(manager.state, SessionState.active);
+        expect(manager.session!.id, sessionId);
+      });
+    });
+
+    test('timeout expiry stops session', () {
+      fakeAsync((async) {
+        manager.startSession();
+        manager.handleAppPaused();
+        async.elapse(timeout);
+        expect(manager.state, SessionState.stopped);
+        expect(manager.session!.stopTimestamp, isNotNull);
+      });
+    });
+
+    test('handleAppResumed after timeout starts new session', () {
+      fakeAsync((async) {
+        manager.startSession();
+        final oldId = manager.session!.id;
+        manager.handleAppPaused();
+        async.elapse(timeout);
+        manager.handleAppResumed();
+        expect(manager.state, SessionState.active);
+        expect(manager.session!.id, isNot(oldId));
+      });
+    });
+
+    test('handleAppPaused is no-op when not active', () {
+      manager.handleAppPaused();
+      expect(manager.state, SessionState.stopped);
+    });
+
+    test('startSession stops existing session first', () {
+      manager.startSession();
+      final firstId = manager.session!.id;
+      manager.startSession();
+      expect(manager.session!.id, isNot(firstId));
+    });
+
+    test('short appId is padded in session ID', () {
+      final shortManager = SessionManager(
+        appId: 'ab',
+        sessionTimeout: timeout,
+        generateId: () => 'uuid0000-fake-uuid-value',
+      );
+      shortManager.startSession();
+      final id = shortManager.session!.id;
+      expect(id.substring(0, 8), '______ab');
+    });
+  });
+}

--- a/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/session_manager_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/session_manager_test.dart
@@ -119,6 +119,85 @@ void main() {
       expect(id.substring(0, 8), '______ab');
     });
 
+    group('explicit stop vs timeout stop', () {
+      test('handleAppResumed does not restart after an explicit stop', () {
+        fakeAsync((async) {
+          manager
+            ..startSession()
+            ..handleAppPaused();
+          final stoppedId = manager.session!.id;
+
+          manager
+            ..stopSession()
+            ..handleAppResumed();
+
+          expect(
+            manager.state,
+            SessionState.stopped,
+            reason: 'a session the customer stopped must stay stopped',
+          );
+          expect(
+            manager.session!.id,
+            stoppedId,
+            reason: 'no new session may be started by the resume',
+          );
+        });
+      });
+
+      test('handleAppResumed does restart after a timeout stop', () {
+        fakeAsync((async) {
+          manager
+            ..startSession()
+            ..handleAppPaused();
+          final timedOutId = manager.session!.id;
+          async.elapse(timeout);
+          expect(manager.state, SessionState.stopped);
+
+          manager.handleAppResumed();
+
+          expect(manager.state, SessionState.active);
+          expect(manager.session!.id, isNot(timedOutId));
+        });
+      });
+
+      test('startSession clears the explicit stop', () {
+        fakeAsync((async) {
+          manager
+            ..startSession()
+            ..stopSession()
+            // Explicitly restarting puts lifecycle handling back in charge.
+            ..startSession();
+          final restartedId = manager.session!.id;
+
+          manager.handleAppPaused();
+          async.elapse(timeout);
+          manager.handleAppResumed();
+
+          expect(manager.state, SessionState.active);
+          expect(manager.session!.id, isNot(restartedId));
+        });
+      });
+
+      test('handleAppResumed does not restart after clearSession', () {
+        manager
+          ..startSession()
+          ..clearSession()
+          ..handleAppResumed();
+        expect(manager.state, SessionState.stopped);
+        expect(manager.session, isNull);
+      });
+
+      test('an explicit stop while active is also not resurrected', () {
+        // The paused-then-stopped path is the one the lifecycle observer
+        // exercises; this covers a stop with no preceding background.
+        manager
+          ..startSession()
+          ..stopSession()
+          ..handleAppResumed();
+        expect(manager.state, SessionState.stopped);
+      });
+    });
+
     group('Session equality', () {
       test('same values are equal with matching hashCodes', () {
         const a = Session(

--- a/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/session_manager_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/session_manager_test.dart
@@ -270,11 +270,13 @@ void main() {
           async.flushMicrotasks();
 
           expect(ended.map((s) => s.id), [first.id]);
-          expect(started.map((s) => s.id), [
-            first.id,
-            suspended.session!.id,
-          ], reason: 'the stop must be reported before the start that replaced '
-              'it');
+          expect(
+            started.map((s) => s.id),
+            [first.id, suspended.session!.id],
+            reason:
+                'the stop must be reported before the start that replaced '
+                'it',
+          );
         });
       });
 
@@ -291,8 +293,72 @@ void main() {
           expect(
             ended.single.duration,
             const Duration(seconds: 2).inMilliseconds,
-            reason: 'the session went inactive when the app backgrounded, so '
+            reason:
+                'the session went inactive when the app backgrounded, so '
                 'the 20 minutes in the background are not session time',
+          );
+        });
+      });
+
+      test('an explicit stop while paused is stamped at the pause', () {
+        fakeAsync((async) {
+          final suspended = suspendedTimerManager()..startSession();
+
+          async.elapse(const Duration(seconds: 2));
+          suspended.handleAppPaused();
+          async.elapse(const Duration(seconds: 1));
+          suspended.stopSession();
+          async.flushMicrotasks();
+
+          expect(
+            ended.single.duration,
+            const Duration(seconds: 2).inMilliseconds,
+            reason:
+                'the session went inactive at the pause, so a stop while '
+                'still backgrounded does not extend it',
+          );
+        });
+      });
+
+      test('an explicit stop during a pause past the timeout is stamped at '
+          'the pause', () {
+        fakeAsync((async) {
+          final suspended = suspendedTimerManager()..startSession();
+
+          async.elapse(const Duration(seconds: 2));
+          suspended.handleAppPaused();
+          async.elapse(background);
+          suspended.stopSession();
+          async.flushMicrotasks();
+
+          expect(
+            ended.single.duration,
+            const Duration(seconds: 2).inMilliseconds,
+            reason:
+                'a stop that only lands after the timeout must make the '
+                'same attribution the timeout paths make',
+          );
+        });
+      });
+
+      test('an explicit stop while active is stamped at the stop', () {
+        fakeAsync((async) {
+          final suspended = suspendedTimerManager()..startSession();
+
+          async.elapse(const Duration(seconds: 2));
+          suspended.handleAppPaused();
+          async.elapse(const Duration(seconds: 1));
+          suspended.handleAppResumed();
+          async.elapse(const Duration(seconds: 2));
+          suspended.stopSession();
+          async.flushMicrotasks();
+
+          expect(
+            ended.single.duration,
+            const Duration(seconds: 5).inMilliseconds,
+            reason:
+                'a resumed session is active again, so its stop is '
+                'measured to now, background dwell included',
           );
         });
       });
@@ -369,14 +435,15 @@ void main() {
         // out until the next full pause/resume cycle.
         fakeAsync((async) {
           ended = [];
-          final timed = SessionManager(
-            appId: 'testApp1',
-            sessionTimeout: timeout,
-            generateId: () => 'abcd${idCounter++}000-fake-uuid-value',
-            onSessionEnded: (s) async => ended.add(s),
-          )
-            ..startSession()
-            ..handleAppPaused();
+          final timed =
+              SessionManager(
+                  appId: 'testApp1',
+                  sessionTimeout: timeout,
+                  generateId: () => 'abcd${idCounter++}000-fake-uuid-value',
+                  onSessionEnded: (s) async => ended.add(s),
+                )
+                ..startSession()
+                ..handleAppPaused();
 
           async
             ..elapse(timeout)
@@ -409,13 +476,14 @@ void main() {
 
       test('a session started after a resume is active', () {
         fakeAsync((async) {
-          final timed = SessionManager(
-            appId: 'testApp1',
-            sessionTimeout: timeout,
-            generateId: () => 'abcd${idCounter++}000-fake-uuid-value',
-          )
-            ..startSession()
-            ..handleAppPaused();
+          final timed =
+              SessionManager(
+                  appId: 'testApp1',
+                  sessionTimeout: timeout,
+                  generateId: () => 'abcd${idCounter++}000-fake-uuid-value',
+                )
+                ..startSession()
+                ..handleAppPaused();
 
           async.elapse(timeout);
           timed

--- a/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/session_manager_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/session_manager_test.dart
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import 'package:amplify_event_enrichment_dart/src/session/session.dart';
 import 'package:amplify_event_enrichment_dart/src/session/session_manager.dart';
 import 'package:fake_async/fake_async.dart';
 import 'package:test/test.dart';
@@ -116,6 +117,37 @@ void main() {
       )..startSession();
       final id = shortManager.session!.id;
       expect(id.substring(0, 8), '______ab');
+    });
+
+    group('Session equality', () {
+      test('same values are equal with matching hashCodes', () {
+        const a = Session(
+          id: 'abc-20260811-120000000',
+          startTimestamp: '2026-08-11T12:00:00.000Z',
+          stopTimestamp: '2026-08-11T12:05:00.000Z',
+          duration: 300000,
+        );
+        const b = Session(
+          id: 'abc-20260811-120000000',
+          startTimestamp: '2026-08-11T12:00:00.000Z',
+          stopTimestamp: '2026-08-11T12:05:00.000Z',
+          duration: 300000,
+        );
+        expect(a, equals(b));
+        expect(a.hashCode, equals(b.hashCode));
+      });
+
+      test('different values are not equal', () {
+        const a = Session(
+          id: 'abc-20260811-120000000',
+          startTimestamp: '2026-08-11T12:00:00.000Z',
+        );
+        const b = Session(
+          id: 'xyz-20260811-130000000',
+          startTimestamp: '2026-08-11T13:00:00.000Z',
+        );
+        expect(a, isNot(equals(b)));
+      });
     });
   });
 }

--- a/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/session_manager_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/session_manager_test.dart
@@ -363,6 +363,68 @@ void main() {
           );
         });
       });
+      test('a session started while backgrounded starts paused', () {
+        // Without tracking the app's own foreground state this session would
+        // be active with no pause timestamp and no timer, so it could not time
+        // out until the next full pause/resume cycle.
+        fakeAsync((async) {
+          ended = [];
+          final timed = SessionManager(
+            appId: 'testApp1',
+            sessionTimeout: timeout,
+            generateId: () => 'abcd${idCounter++}000-fake-uuid-value',
+            onSessionEnded: (s) async => ended.add(s),
+          )
+            ..startSession()
+            ..handleAppPaused();
+
+          async
+            ..elapse(timeout)
+            ..flushMicrotasks();
+          expect(
+            timed.state,
+            SessionState.stopped,
+            reason: 'the first session timed out while backgrounded',
+          );
+
+          // Still backgrounded: nothing has resumed.
+          timed.startSession();
+
+          expect(
+            timed.state,
+            SessionState.paused,
+            reason: 'a session cannot be active while the app is not',
+          );
+          async
+            ..elapse(timeout)
+            ..flushMicrotasks();
+          expect(
+            timed.state,
+            SessionState.stopped,
+            reason: 'the second session has to be able to time out too',
+          );
+          expect(ended, hasLength(2));
+        });
+      });
+
+      test('a session started after a resume is active', () {
+        fakeAsync((async) {
+          final timed = SessionManager(
+            appId: 'testApp1',
+            sessionTimeout: timeout,
+            generateId: () => 'abcd${idCounter++}000-fake-uuid-value',
+          )
+            ..startSession()
+            ..handleAppPaused();
+
+          async.elapse(timeout);
+          timed
+            ..handleAppResumed()
+            ..startSession();
+
+          expect(timed.state, SessionState.active);
+        });
+      });
     });
 
     group('Session equality', () {

--- a/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/session_manager_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/session_manager_test.dart
@@ -1,10 +1,27 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import 'dart:async';
+
 import 'package:amplify_event_enrichment_dart/src/session/session.dart';
 import 'package:amplify_event_enrichment_dart/src/session/session_manager.dart';
 import 'package:fake_async/fake_async.dart';
 import 'package:test/test.dart';
+
+/// A timer that never runs its callback, standing in for a platform that
+/// suspends timers while the app is backgrounded. iOS suspends the Dart event
+/// loop, so the pause timer may not run until after the app is already back in
+/// the foreground, or at all — the resume has to detect the timeout itself.
+class _NeverFiringTimer implements Timer {
+  @override
+  void cancel() {}
+
+  @override
+  bool get isActive => true;
+
+  @override
+  int get tick => 0;
+}
 
 void main() {
   group('SessionManager', () {
@@ -195,6 +212,156 @@ void main() {
           ..stopSession()
           ..handleAppResumed();
         expect(manager.state, SessionState.stopped);
+      });
+    });
+
+    group('background timeout measured by timestamp', () {
+      const background = Duration(minutes: 20);
+      late List<Session> ended;
+      late List<Session> started;
+
+      /// A manager whose pause timer never fires, so only the timestamp
+      /// comparison on resume can detect the timeout.
+      SessionManager suspendedTimerManager() {
+        ended = [];
+        started = [];
+        return SessionManager(
+          appId: 'testApp1',
+          sessionTimeout: timeout,
+          generateId: () => 'abcd${idCounter++}000-fake-uuid-value',
+          onSessionStarted: (s) async => started.add(s),
+          onSessionEnded: (s) async => ended.add(s),
+        )..timerFactory = (_, _) => _NeverFiringTimer();
+      }
+
+      test('a resume past the timeout starts a new session', () {
+        fakeAsync((async) {
+          final suspended = suspendedTimerManager()..startSession();
+          final first = suspended.session!;
+
+          suspended.handleAppPaused();
+          async.elapse(background);
+          suspended.handleAppResumed();
+          async.flushMicrotasks();
+
+          expect(
+            suspended.state,
+            SessionState.active,
+            reason: 'the app is in the foreground again',
+          );
+          expect(
+            suspended.session!.id,
+            isNot(first.id),
+            reason: 'a 20 minute background is not the same session',
+          );
+        });
+      });
+
+      test('the timed-out session is reported stopped, then the new one '
+          'started', () {
+        fakeAsync((async) {
+          final suspended = suspendedTimerManager()..startSession();
+          final first = suspended.session!;
+          async.flushMicrotasks();
+
+          suspended.handleAppPaused();
+          async.elapse(background);
+          suspended.handleAppResumed();
+          async.flushMicrotasks();
+
+          expect(ended.map((s) => s.id), [first.id]);
+          expect(started.map((s) => s.id), [
+            first.id,
+            suspended.session!.id,
+          ], reason: 'the stop must be reported before the start that replaced '
+              'it');
+        });
+      });
+
+      test('the stop is stamped at the pause, not at the resume', () {
+        fakeAsync((async) {
+          final suspended = suspendedTimerManager()..startSession();
+
+          async.elapse(const Duration(seconds: 2));
+          suspended.handleAppPaused();
+          async.elapse(background);
+          suspended.handleAppResumed();
+          async.flushMicrotasks();
+
+          expect(
+            ended.single.duration,
+            const Duration(seconds: 2).inMilliseconds,
+            reason: 'the session went inactive when the app backgrounded, so '
+                'the 20 minutes in the background are not session time',
+          );
+        });
+      });
+
+      test('a resume inside the timeout still resumes the same session', () {
+        fakeAsync((async) {
+          final suspended = suspendedTimerManager()..startSession();
+          final first = suspended.session!;
+          async.flushMicrotasks();
+
+          suspended.handleAppPaused();
+          async.elapse(timeout - const Duration(milliseconds: 1));
+          suspended.handleAppResumed();
+          async.flushMicrotasks();
+
+          expect(suspended.state, SessionState.active);
+          expect(suspended.session!.id, first.id);
+          expect(ended, isEmpty, reason: 'resuming is not a boundary');
+          expect(started.map((s) => s.id), [first.id]);
+        });
+      });
+
+      test('an explicit stop is not resurrected by a late resume', () {
+        fakeAsync((async) {
+          final suspended = suspendedTimerManager()
+            ..startSession()
+            ..handleAppPaused()
+            ..stopSession();
+          final stoppedId = suspended.session!.id;
+          async.elapse(background);
+          suspended.handleAppResumed();
+          async.flushMicrotasks();
+
+          expect(
+            suspended.state,
+            SessionState.stopped,
+            reason: 'the elapsed-time path must not override an explicit stop',
+          );
+          expect(suspended.session!.id, stoppedId);
+        });
+      });
+
+      test('the timer path stamps the stop at the pause too', () {
+        // The real timer, on a platform that runs it. Both paths have to
+        // attribute the stop the same way or the same background produces two
+        // different durations.
+        fakeAsync((async) {
+          final timed = SessionManager(
+            appId: 'testApp1',
+            sessionTimeout: timeout,
+            generateId: () => 'abcd${idCounter++}000-fake-uuid-value',
+            onSessionEnded: (s) async => ended.add(s),
+          );
+          ended = [];
+
+          timed.startSession();
+          async.elapse(const Duration(seconds: 2));
+          timed.handleAppPaused();
+          async
+            ..elapse(timeout)
+            ..flushMicrotasks();
+
+          expect(timed.state, SessionState.stopped);
+          expect(
+            ended.single.duration,
+            const Duration(seconds: 2).inMilliseconds,
+            reason: 'not 2s + the timeout window',
+          );
+        });
       });
     });
 

--- a/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/session_manager_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/session_manager_test.dart
@@ -136,6 +136,65 @@ void main() {
       expect(id.substring(0, 8), '______ab');
     });
 
+    group('calls made without awaiting the previous one', () {
+      late List<String> boundaries;
+
+      /// A manager that logs its boundaries to one list, so a test can pin the
+      /// order two calls report them in and not just how many there were.
+      SessionManager reportingManager() {
+        boundaries = [];
+        return SessionManager(
+          appId: 'testApp1',
+          sessionTimeout: timeout,
+          generateId: () => 'abcd${idCounter++}000-fake-uuid-value',
+          onSessionStarted: (s) async => boundaries.add('start ${s.id}'),
+          onSessionEnded: (s) async => boundaries.add('end ${s.id}'),
+        );
+      }
+
+      test('two startSession calls displace the first session', () async {
+        final reporting = reportingManager();
+
+        final first = reporting.startSession();
+        final displaced = reporting.session!;
+        final second = reporting.startSession();
+        await Future.wait([first, second]);
+
+        final replacement = reporting.session!;
+        expect(reporting.state, SessionState.active);
+        expect(replacement.id, isNot(displaced.id));
+        expect(
+          boundaries,
+          [
+            'start ${displaced.id}',
+            'end ${displaced.id}',
+            'start ${replacement.id}',
+          ],
+          reason:
+              'the second call ends the session the first started before '
+              'reporting the replacement',
+        );
+      });
+
+      test('two sessionForRecording calls share one session', () async {
+        final reporting = reportingManager();
+
+        final first = reporting.sessionForRecording();
+        final second = reporting.sessionForRecording();
+        final sessions = await Future.wait([first, second]);
+
+        expect(sessions.first.id, sessions.last.id);
+        expect(sessions.first.id, reporting.session!.id);
+        expect(
+          boundaries,
+          ['start ${reporting.session!.id}'],
+          reason:
+              'the second call finds the session the first one already '
+              'started, so there is nothing left to start',
+        );
+      });
+    });
+
     group('explicit stop vs timeout stop', () {
       test('handleAppResumed does not restart after an explicit stop', () {
         fakeAsync((async) {

--- a/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/session_stop_event_test.dart
+++ b/packages/amplify_event_enrichment/amplify_event_enrichment_dart/test/session_stop_event_test.dart
@@ -1,0 +1,399 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_event_enrichment_dart/amplify_event_enrichment.dart';
+import 'package:amplify_foundation_dart/amplify_foundation_dart.dart';
+import 'package:fake_async/fake_async.dart';
+import 'package:test/test.dart';
+
+class _RecordingSender implements Sender {
+  final List<EnrichedEvent> events = [];
+
+  @override
+  Future<void> send(EnrichedEvent event) async => events.add(event);
+
+  /// Only the session-stop events, so counts are unaffected by whatever the
+  /// test recorded to get a session started.
+  List<EnrichedEvent> get sessionStops =>
+      events.where((e) => e.eventType == zSessionStopEventType).toList();
+}
+
+/// Fails after suspending — the case a synchronous throw does not cover, and
+/// the one that escapes as an unhandled async error if the emission is not
+/// awaited inside its own guard.
+class _AsyncFailingSender implements Sender {
+  int sendCount = 0;
+
+  @override
+  Future<void> send(EnrichedEvent event) async {
+    sendCount++;
+    await Future<void>.delayed(Duration.zero);
+    throw StateError('async sender failure');
+  }
+}
+
+void main() {
+  group('session stop event emission', () {
+    const app = AppMetadata(
+      appId: 'testApp1',
+      packageName: 'com.example',
+      versionName: '1.0.0',
+      title: 'Test',
+    );
+    const device = DeviceMetadata(
+      platform: 'iOS',
+      platformVersion: '17.0',
+      manufacturer: 'Apple',
+      model: 'iPhone',
+      locale: 'en_US',
+    );
+    const sdk = SdkMetadata(name: 'amplify-flutter', version: '2.0.0');
+    const timeout = Duration(seconds: 5);
+
+    EventEnrichmentClient buildClient(
+      Sender sender, {
+      bool autoSessionTracking = true,
+    }) => EventEnrichmentClient(
+      appMetadata: app,
+      deviceMetadata: device,
+      sdkMetadata: sdk,
+      clientId: 'device-123',
+      sender: sender,
+      options: EventEnrichmentClientOptions(
+        autoSessionTracking: autoSessionTracking,
+        sessionTimeout: timeout,
+      ),
+    );
+
+    late _RecordingSender sender;
+    late EventEnrichmentClient client;
+
+    setUp(() {
+      sender = _RecordingSender();
+      client = buildClient(sender);
+    });
+
+    group('emits', () {
+      test(
+        'on an explicit stopSession(), carrying the stopped session',
+        () async {
+          final started = client.sessionManager.session!;
+
+          await client.stopSession();
+
+          expect(sender.sessionStops, hasLength(1));
+          final event = sender.sessionStops.single;
+          expect(event.eventType, '_session.stop');
+          expect(
+            event.session.id,
+            started.id,
+            reason: 'the event must carry the session that ended',
+          );
+          expect(event.session.startTimestamp, started.startTimestamp);
+          expect(event.session.stopTimestamp, isNotNull);
+          expect(event.session.duration, isNotNull);
+        },
+      );
+
+      test('with the same enrichment a recorded event gets', () async {
+        client
+          ..setUserId('user-1')
+          ..addGlobalAttribute('env', 'prod')
+          ..addGlobalMetric('score', 4.5);
+
+        await client.stopSession();
+
+        final event = sender.sessionStops.single;
+        expect(event.app.appId, 'testApp1');
+        expect(event.device.platform, 'iOS');
+        expect(event.sdk.name, 'amplify-flutter');
+        expect(event.clientId, 'device-123');
+        expect(event.userId, 'user-1');
+        expect(event.eventId, isNotEmpty);
+        // Pinpoint stamped its globals on _session.stop too, so these are
+        // deliberately present rather than stripped.
+        expect(event.attributes['env'], 'prod');
+        expect(event.metrics['score'], 4.5);
+      });
+
+      test('when a paused session is stopped', () async {
+        client.handleAppPaused();
+        expect(client.sessionManager.state, SessionState.paused);
+
+        await client.stopSession();
+
+        expect(sender.sessionStops, hasLength(1));
+      });
+
+      test('when the session timeout expires while backgrounded', () {
+        fakeAsync((async) {
+          final timeoutSender = _RecordingSender();
+          final timeoutClient = buildClient(timeoutSender);
+          final started = timeoutClient.sessionManager.session!;
+
+          timeoutClient.handleAppPaused();
+          // The timer callback has no caller to await, so drain the emission
+          // the way the event loop would.
+          async
+            ..elapse(timeout)
+            ..flushMicrotasks();
+
+          expect(timeoutSender.sessionStops, hasLength(1));
+          expect(timeoutSender.sessionStops.single.session.id, started.id);
+          expect(timeoutSender.sessionStops.single.session.duration, isNotNull);
+        });
+      });
+
+      test('on close() when a session is still running', () async {
+        final started = client.sessionManager.session!;
+
+        await client.close();
+
+        expect(sender.sessionStops, hasLength(1));
+        expect(sender.sessionStops.single.session.id, started.id);
+      });
+
+      test('for the session startSession() displaces', () async {
+        final displaced = client.sessionManager.session!;
+
+        await client.startSession();
+
+        expect(sender.sessionStops, hasLength(1));
+        expect(
+          sender.sessionStops.single.session.id,
+          displaced.id,
+          reason: 'the displaced session is the one that ended',
+        );
+        expect(
+          client.sessionManager.session!.id,
+          isNot(displaced.id),
+          reason: 'a new session must be active afterwards',
+        );
+      });
+    });
+
+    group('does not emit', () {
+      test('when no session was ever started', () async {
+        final idle = buildClient(sender, autoSessionTracking: false);
+        expect(idle.sessionManager.session, isNull);
+
+        await idle.stopSession();
+
+        expect(sender.sessionStops, isEmpty);
+        await idle.close();
+      });
+
+      test('on close() when no session was ever started', () async {
+        final idle = buildClient(sender, autoSessionTracking: false);
+
+        await idle.close();
+
+        expect(sender.sessionStops, isEmpty);
+      });
+
+      test('a second time when stopSession() is called twice', () async {
+        await client.stopSession();
+        await client.stopSession();
+
+        expect(sender.sessionStops, hasLength(1));
+      });
+
+      test('a second time on close() after an explicit stop', () async {
+        await client.stopSession();
+        await client.close();
+
+        expect(
+          sender.sessionStops,
+          hasLength(1),
+          reason: 'the session already ended, so close() has nothing to end',
+        );
+      });
+
+      test('a second time on close() after a session timeout', () {
+        fakeAsync((async) {
+          final timeoutSender = _RecordingSender();
+          final timeoutClient = buildClient(timeoutSender)..handleAppPaused();
+
+          async
+            ..elapse(timeout)
+            ..flushMicrotasks();
+          expect(timeoutSender.sessionStops, hasLength(1));
+
+          timeoutClient.close();
+          async.flushMicrotasks();
+
+          expect(timeoutSender.sessionStops, hasLength(1));
+        });
+      });
+      test('on the first startSession() when nothing is running', () async {
+        final idle = buildClient(sender, autoSessionTracking: false);
+
+        await idle.startSession();
+
+        expect(sender.sessionStops, isEmpty);
+        expect(idle.sessionManager.state, SessionState.active);
+        await idle.close();
+      });
+
+      test('when a pause and resume stay within the timeout', () {
+        fakeAsync((async) {
+          final pauseSender = _RecordingSender();
+          final pauseClient = buildClient(pauseSender);
+          final started = pauseClient.sessionManager.session!;
+
+          pauseClient.handleAppPaused();
+          async.elapse(const Duration(seconds: 3));
+          pauseClient.handleAppResumed();
+          async.flushMicrotasks();
+
+          expect(pauseSender.sessionStops, isEmpty);
+          expect(pauseClient.sessionManager.session!.id, started.id);
+        });
+      });
+
+      test('again when handleAppResumed follows an explicit stop', () async {
+        await client.stopSession();
+        client.handleAppResumed();
+
+        expect(sender.sessionStops, hasLength(1));
+        expect(client.sessionManager.state, SessionState.stopped);
+      });
+
+      test('again from the pause timer after an explicit stop', () {
+        // The pending timeout still fires after an explicit stop (the stop
+        // cancels the timer, but a timer that slipped through would find the
+        // session already ended). Either way it must not report it twice.
+        fakeAsync((async) {
+          final lateSender = _RecordingSender();
+          buildClient(lateSender)
+            ..handleAppPaused()
+            ..stopSession();
+
+          async
+            ..flushMicrotasks()
+            ..elapse(timeout * 2)
+            ..flushMicrotasks();
+
+          expect(lateSender.sessionStops, hasLength(1));
+        });
+      });
+
+      test('again from the pause timer after close()', () {
+        fakeAsync((async) {
+          final lateSender = _RecordingSender();
+          buildClient(lateSender)
+            ..handleAppPaused()
+            ..close();
+
+          async
+            ..flushMicrotasks()
+            ..elapse(timeout * 2)
+            ..flushMicrotasks();
+
+          expect(lateSender.sessionStops, hasLength(1));
+        });
+      });
+
+      test(
+        'again when record() lazily starts a session after a stop',
+        () async {
+          await client.record('first');
+          await client.stopSession();
+          await client.record('second');
+
+          expect(
+            sender.sessionStops,
+            hasLength(1),
+            reason: 'the lazy start displaces nothing, so it ends nothing',
+          );
+          expect(sender.events.map((e) => e.eventType), [
+            'first',
+            zSessionStopEventType,
+            'second',
+          ]);
+        },
+      );
+    });
+
+    test('each session is reported exactly once across a timeout cycle', () {
+      // Two sessions live and die here, so two stops — one per session, and
+      // never two for the same one.
+      fakeAsync((async) {
+        final cycleSender = _RecordingSender();
+        final cycleClient = buildClient(cycleSender);
+        final first = cycleClient.sessionManager.session!;
+
+        cycleClient.handleAppPaused();
+        async
+          ..elapse(timeout)
+          ..flushMicrotasks();
+        cycleClient.handleAppResumed();
+        final second = cycleClient.sessionManager.session!;
+        expect(second.id, isNot(first.id));
+
+        cycleClient.stopSession();
+        async.flushMicrotasks();
+
+        expect(cycleSender.sessionStops.map((e) => e.session.id), [
+          first.id,
+          second.id,
+        ]);
+      });
+    });
+
+    group('sender failures', () {
+      test('are logged rather than thrown out of stopSession()', () async {
+        final failing = _AsyncFailingSender();
+        final failingClient = buildClient(failing);
+
+        // The sender suspends before failing, so this only passes because the
+        // emission awaits send() inside its own guard. An error escaping to
+        // the zone fails this test.
+        await expectLater(failingClient.stopSession(), completes);
+        expect(failing.sendCount, 1);
+        expect(failingClient.sessionManager.state, SessionState.stopped);
+
+        await expectLater(failingClient.close(), completes);
+      });
+
+      test('are logged rather than thrown out of close()', () async {
+        final failing = _AsyncFailingSender();
+        final failingClient = buildClient(failing);
+
+        await expectLater(failingClient.close(), completes);
+        expect(failing.sendCount, 1);
+        expect(failingClient.isClosed, isTrue);
+      });
+
+      test('do not stop a later session from being started', () async {
+        final failing = _AsyncFailingSender();
+        final failingClient = buildClient(failing);
+
+        await failingClient.stopSession();
+        final result = await failingClient.record('after_failure');
+
+        expect(
+          result,
+          isA<Error<EnrichedEvent>>(),
+          reason: 'record() still surfaces its own send failure',
+        );
+        expect(failingClient.sessionManager.state, SessionState.active);
+        await failingClient.close();
+      });
+    });
+
+    test('no session stop event is emitted without a sender', () async {
+      final senderless = EventEnrichmentClient(
+        appMetadata: app,
+        deviceMetadata: device,
+        sdkMetadata: sdk,
+        clientId: 'device-123',
+      );
+
+      // Nothing to assert on but the absence of a throw: the emission path is
+      // a no-op with no sender configured.
+      await expectLater(senderless.stopSession(), completes);
+      await expectLater(senderless.close(), completes);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Splits the unit tests for the Event Enrichment packages into their own PR so the core implementation and the tests review independently.

> **Stacked on #7029.** This targets the `feat/event-enrichment-client` branch (the package PR), so the diff shows only the test files. Once #7029 merges, this will be rebased onto `main`.

### What's here

- `amplify_event_enrichment_dart/test/`: enriched event serialization, client, global fields manager, session manager
- `amplify_event_enrichment/test/`: Flutter lifecycle observer

### Verification

- `amplify_event_enrichment_dart`: **41 tests pass** (`dart test`)
- `amplify_event_enrichment` (Flutter wrapper): **6 tests pass** (`flutter test`)
- Analyzer clean (0 errors, 0 warnings)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
