### PR TITLE
fix(worker_bee): Exclude example from default build target

### DIFF
--- a/packages/worker_bee/worker_bee/build.yaml
+++ b/packages/worker_bee/worker_bee/build.yaml
@@ -1,0 +1,6 @@
+targets:
+  $default:
+    # The example is a Flutter app and builds via its own build.yaml.
+    sources:
+      exclude:
+        - example/**


### PR DESCRIPTION
`aft publish --force` runs `build_runner` for `worker_bee`, which builds the whole package graph including the `example/` sub-package. The example is a Flutter app with web entrypoints, and `build_web_compilers` can't resolve `package:flutter` under a plain `dart run build_runner`, so it fails:

```
E build_web_compilers:entrypoint on example/lib/main.dart:
  Unable to find modules for some sources ...
  `import 'package:flutter/material.dart';`
```

Fix: exclude `example/**` from `worker_bee`'s `$default` target, same as `aws_common/build.yaml`. `worker_bee` only uses `build_web_compilers` for its own browser tests, which still work.