### PR TITLE
test(amplify_push): add Dart and Android unit tests

### DIFF
--- a/packages/amplify_push/android/src/test/kotlin/com/amazonaws/amplify/amplify_push_notifications/AmplifyPushNotificationsPluginTest.kt
+++ b/packages/amplify_push/android/src/test/kotlin/com/amazonaws/amplify/amplify_push_notifications/AmplifyPushNotificationsPluginTest.kt
@@ -1,0 +1,282 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazonaws.amplify.amplify_push_notifications
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.content.SharedPreferences
+import androidx.core.app.ActivityCompat
+import androidx.lifecycle.Lifecycle
+import com.amplifyframework.annotations.InternalAmplifyApi
+import com.amplifyframework.notifications.pushnotifications.NotificationContentProvider
+import com.amplifyframework.notifications.pushnotifications.NotificationPayload
+import com.amplifyframework.pushnotifications.pinpoint.permissions.PermissionRequestResult.*
+import com.amplifyframework.pushnotifications.pinpoint.permissions.PushNotificationPermission
+import com.google.android.gms.tasks.Task
+import com.google.firebase.messaging.FirebaseMessaging
+import io.flutter.embedding.engine.plugins.FlutterPlugin.FlutterPluginBinding
+import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
+import io.flutter.embedding.engine.plugins.lifecycle.FlutterLifecycleAdapter
+import io.flutter.plugin.common.BinaryMessenger
+import io.flutter.plugin.common.EventChannel
+import io.flutter.plugin.common.EventChannel.EventSink
+import io.mockk.*
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers
+import org.robolectric.RobolectricTestRunner
+
+
+@InternalAmplifyApi
+@ExperimentalCoroutinesApi
+@RunWith(RobolectricTestRunner::class)
+class AmplifyPushNotificationsPluginTest {
+
+    private lateinit var amplifyPushNotificationsPlugin: AmplifyPushNotificationsPlugin
+    private lateinit var mockEventSink: EventSink
+    private val testPayload = NotificationPayload.Builder(
+        NotificationContentProvider.FCM(emptyMap())
+    ).build()
+    private val mockTask = mockk<Task<String>>()
+    private lateinit var context: Context
+    private val mockSharedPreferences = mockk<SharedPreferences>()
+    private val mockActivityBinding = mockk<ActivityPluginBinding>(relaxed = true)
+    private val mockResult =
+        mockk<PushNotificationsHostApiBindings.Result<PushNotificationsHostApiBindings.GetPermissionStatusResult>>()
+    private val mockFlutterBinding = mockk<FlutterPluginBinding>()
+
+    @Before
+    fun setUp() {
+        context = mockk()
+        mockEventSink = mockk()
+        val mockedBinaryMessenger = mockk<BinaryMessenger>()
+        val mockLifeCycle = mockk<Lifecycle>()
+        val mockActivity = mockk<Activity>()
+
+        mockkObject(NotificationPayload)
+        mockkStatic(FirebaseMessaging::class)
+        mockkStatic(NotificationPayload::toWritableMap)
+        mockkStatic(PushNotificationPermission::class)
+        mockkStatic(Task::class)
+        mockkStatic(FlutterLifecycleAdapter::class)
+        mockkStatic(::refreshToken)
+        mockkConstructor(EventSink::class)
+        mockkConstructor(PushNotificationsHostApiBindings.GetPermissionStatusResult.Builder::class)
+        mockkConstructor(EventChannel::class)
+        mockkConstructor(PushNotificationPermission::class)
+
+        every { anyConstructed<EventChannel>().setStreamHandler(any()) } returns
+                StreamHandlers.initStreamHandlers(refresh = true)
+        every {
+            context.getSharedPreferences(
+                PushNotificationPluginConstants.SHARED_PREFERENCES_KEY,
+                Context.MODE_PRIVATE
+            )
+        } returns mockSharedPreferences
+        every { mockSharedPreferences.getBoolean(any(), any()) } returns false
+        every { FirebaseMessaging.getInstance().token } returns mockTask
+        every { NotificationPayload.fromIntent(any()) } returns testPayload
+        every { anyConstructed<PushNotificationPermission>().hasRequiredPermission } returns false
+        every { mockFlutterBinding.binaryMessenger } returns mockedBinaryMessenger
+        every { mockFlutterBinding.binaryMessenger.setMessageHandler(any(), any()) } returns mockk()
+        every { mockFlutterBinding.flutterEngine } returns mockk()
+        every { mockFlutterBinding.applicationContext } returns context
+        every { refreshToken() } returns mockk()
+
+        every { FlutterLifecycleAdapter.getActivityLifecycle(any()) } returns mockLifeCycle
+        every { mockLifeCycle.addObserver(any()) } returns mockk()
+        every { mockActivityBinding.activity } returns mockActivity
+        every { mockActivity.intent } returns mockk()
+        every { mockResult.success(any()) } returns mockk()
+
+        every {
+            anyConstructed<PushNotificationsHostApiBindings.GetPermissionStatusResult.Builder>().setStatus(
+                any()
+            )
+        } returns mockk()
+        every { anyConstructed<PushNotificationsHostApiBindings.GetPermissionStatusResult.Builder>().build() } returns mockk()
+
+        amplifyPushNotificationsPlugin = AmplifyPushNotificationsPlugin()
+        StreamHandlers.initEventChannels(mockedBinaryMessenger)
+        amplifyPushNotificationsPlugin.onAttachedToEngine(mockFlutterBinding)
+
+    }
+
+    @After
+    fun tearDown() {
+        StreamHandlers.deInit()
+        unmockkStatic(::refreshToken)
+        unmockkObject(NotificationPayload)
+        unmockkStatic(FirebaseMessaging::class)
+        unmockkStatic(NotificationPayload::toWritableMap)
+        unmockkStatic(PushNotificationPermission::class)
+    }
+
+    @Test
+    fun `onNewIntent does nothing if intent does not contain payload`() {
+        every { NotificationPayload.fromIntent(any()) } returns null
+        amplifyPushNotificationsPlugin.onNewIntent(Intent())
+
+        StreamHandlers.notificationOpened!!.onListen(ArgumentMatchers.any(), mockEventSink)
+        verify(exactly = 0) {
+            mockEventSink.success(any())
+        }
+    }
+
+    @Test
+    fun `onNewIntent sends notification opened event if intent contains payload`() {
+        amplifyPushNotificationsPlugin.onNewIntent(Intent())
+        StreamHandlers.notificationOpened!!.onListen(ArgumentMatchers.any(), mockEventSink)
+        verify(exactly = 1) {
+            mockEventSink.success(any())
+        }
+    }
+
+    @Test
+    fun `getLaunchNotification is available only when the app starts from a killed state`() {
+        amplifyPushNotificationsPlugin.onNewIntent(
+            Intent().putExtra(
+                PushNotificationPluginConstants.IS_LAUNCH_NOTIFICATION,
+                true
+            )
+        )
+        assertEquals(amplifyPushNotificationsPlugin.launchNotification, testPayload.toWritableMap())
+    }
+
+    @Test
+    fun `getLaunchNotification is wiped when accessed more than once`() {
+        amplifyPushNotificationsPlugin.onNewIntent(
+            Intent().putExtra(
+                PushNotificationPluginConstants.IS_LAUNCH_NOTIFICATION,
+                true
+            )
+        )
+        assertEquals(amplifyPushNotificationsPlugin.launchNotification, testPayload.toWritableMap())
+        assertNull(amplifyPushNotificationsPlugin.launchNotification)
+    }
+
+
+    @Test
+    fun `returns Granted permission status`() {
+        every { anyConstructed<PushNotificationPermission>().hasRequiredPermission } returns true
+
+        amplifyPushNotificationsPlugin.getPermissionStatus(mockResult)
+        verify {
+            anyConstructed<PushNotificationsHostApiBindings.GetPermissionStatusResult.Builder>().setStatus(
+                PushNotificationsHostApiBindings.PermissionStatus.GRANTED
+            )
+        }
+    }
+
+    @Test
+    fun `returns ShouldExplainThenRequest permission status`() {
+        every { anyConstructed<PushNotificationPermission>().hasRequiredPermission } returns false
+
+        mockkStatic(ActivityCompat::class)
+        every { ActivityCompat.shouldShowRequestPermissionRationale(any(), any()) } returns true
+        every { NotificationPayload.fromIntent(any()) } returns null
+
+        amplifyPushNotificationsPlugin.onAttachedToActivity(mockActivityBinding)
+        amplifyPushNotificationsPlugin.getPermissionStatus(mockResult)
+        verify {
+            anyConstructed<PushNotificationsHostApiBindings.GetPermissionStatusResult.Builder>().setStatus(
+                PushNotificationsHostApiBindings.PermissionStatus.SHOULD_EXPLAIN_THEN_REQUEST
+            )
+        }
+    }
+
+    @Test
+    fun `returns Denied permission status`() {
+        every { anyConstructed<PushNotificationPermission>().hasRequiredPermission } returns false
+
+        mockkStatic(ActivityCompat::class)
+        every { ActivityCompat.shouldShowRequestPermissionRationale(any(), any()) } returns false
+        every { NotificationPayload.fromIntent(any()) } returns null
+        every {
+            mockSharedPreferences.getBoolean(
+                PushNotificationPluginConstants.PREF_PREVIOUSLY_DENIED, false
+            )
+        } returns true
+
+        amplifyPushNotificationsPlugin.onAttachedToActivity(mockActivityBinding)
+        amplifyPushNotificationsPlugin.getPermissionStatus(mockResult)
+        verify {
+            anyConstructed<PushNotificationsHostApiBindings.GetPermissionStatusResult.Builder>().setStatus(
+                PushNotificationsHostApiBindings.PermissionStatus.DENIED
+            )
+        }
+    }
+
+    @Test
+    fun `returns ShouldRequest permission status`() {
+        every { anyConstructed<PushNotificationPermission>().hasRequiredPermission } returns false
+
+        mockkStatic(ActivityCompat::class)
+        every { ActivityCompat.shouldShowRequestPermissionRationale(any(), any()) } returns false
+        every { NotificationPayload.fromIntent(any()) } returns null
+        every {
+            mockSharedPreferences.getBoolean(
+                PushNotificationPluginConstants.PREF_PREVIOUSLY_DENIED, false
+            )
+        } returns false
+
+        amplifyPushNotificationsPlugin.onAttachedToActivity(mockActivityBinding)
+        amplifyPushNotificationsPlugin.getPermissionStatus(mockResult)
+        verify {
+            anyConstructed<PushNotificationsHostApiBindings.GetPermissionStatusResult.Builder>().setStatus(
+                PushNotificationsHostApiBindings.PermissionStatus.SHOULD_REQUEST
+            )
+        }
+    }
+
+    @Test
+    fun `requests permission`() = runTest {
+        coEvery { anyConstructed<PushNotificationPermission>().requestPermission() } returns Granted
+        val mockResult = mockk<PushNotificationsHostApiBindings.Result<Boolean>>()
+        every { mockResult.success(any()) } returns mockk()
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val pluginWithDispatcher  = AmplifyPushNotificationsPlugin(dispatcher)
+        pluginWithDispatcher.onAttachedToEngine(mockFlutterBinding)
+        pluginWithDispatcher.requestPermissions(mockk(), mockResult)
+        advanceUntilIdle()
+        verify { mockResult.success(true) }
+    }
+
+    @Test
+    fun `requests permission sets previously denied flag`() = runTest {
+        val mockSharedPreferencesEditor = mockk<SharedPreferences.Editor>()
+        justRun { mockSharedPreferencesEditor.apply() }
+        every { mockSharedPreferences.edit() } returns mockSharedPreferencesEditor
+        every {
+            mockSharedPreferencesEditor.putBoolean(
+                any(), any()
+            )
+        } returns mockSharedPreferencesEditor
+        coEvery { anyConstructed<PushNotificationPermission>().requestPermission() } returns NotGranted(
+            shouldShowRationale = true
+        )
+        val mockResult = mockk<PushNotificationsHostApiBindings.Result<Boolean>>()
+        every { mockResult.success(any()) } returns mockk()
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val pluginWithDispatcher  = AmplifyPushNotificationsPlugin(dispatcher)
+        pluginWithDispatcher.onAttachedToEngine(mockFlutterBinding)
+        pluginWithDispatcher.requestPermissions(mockk(), mockResult)
+        advanceUntilIdle()
+        verify {
+            mockResult.success(false)
+            mockSharedPreferencesEditor.putBoolean(
+                PushNotificationPluginConstants.PREF_PREVIOUSLY_DENIED,
+                true
+            )
+        }
+    }
+}

--- a/packages/amplify_push/android/src/test/kotlin/com/amazonaws/amplify/amplify_push_notifications/InternalPushNotificationUtilsTest.kt
+++ b/packages/amplify_push/android/src/test/kotlin/com/amazonaws/amplify/amplify_push_notifications/InternalPushNotificationUtilsTest.kt
@@ -1,0 +1,337 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazonaws.amplify.amplify_push_notifications
+
+import android.content.ComponentName
+import android.content.Context
+import android.os.Bundle
+import androidx.test.core.app.ApplicationProvider
+import com.amazonaws.amplify.amplify_push_notifications.*
+import com.amplifyframework.annotations.InternalAmplifyApi
+import com.amplifyframework.notifications.pushnotifications.NotificationContentProvider
+import com.amplifyframework.notifications.pushnotifications.NotificationPayload
+import com.amplifyframework.pushnotifications.pinpoint.PushNotificationsConstants
+import com.amplifyframework.pushnotifications.pinpoint.PushNotificationsUtils
+import com.amplifyframework.pushnotifications.pinpoint.permissions.PermissionRequestResult
+import com.amplifyframework.pushnotifications.pinpoint.permissions.PushNotificationPermission
+import com.google.android.gms.tasks.OnCompleteListener
+import com.google.android.gms.tasks.Task
+import com.google.firebase.messaging.FirebaseMessaging
+import io.flutter.plugin.common.EventChannel
+import io.mockk.*
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import java.lang.Exception
+import kotlin.random.Random
+
+@InternalAmplifyApi
+@RunWith(RobolectricTestRunner::class)
+class InternalPushNotificationUtilsTest {
+    private object TestConst {
+        const val ADHOC_KEY = "foo"
+        const val ADHOC_VAL = "bar"
+        const val BODY = "body"
+        const val CAMPAIGN_ID = "campaign-id"
+        const val CAMPAIGN_ACTIVITY_ID = "campaign-activity-id"
+        const val DEEPLINK_URL = "deeplink://url"
+        const val IMAGE_URL = "http://image.fakeurl/avocado.png"
+        const val JOURNEY_ID = "journey-id"
+        const val JOURNEY_ACTIVITY_ID = "journey-id"
+        const val RANDOM_INT = 123
+        const val TITLE = "title"
+        const val URL = "https://goto.fakeurl"
+    }
+
+    private fun getTestPayload(data: Map<String, String> = mapOf()): NotificationPayload {
+        return NotificationPayload.Builder(
+            NotificationContentProvider.FCM(
+                mapOf(PushNotificationsConstants.PINPOINT_PREFIX to "").plus(data)
+            )
+        ).build()
+    }
+
+    private lateinit var context: Context
+    private val mockTask = mockk<Task<String>>()
+    private val tokenOnCompleteListenerSlot = slot<OnCompleteListener<String>>()
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        mockkConstructor(PushNotificationPermission::class)
+        mockkConstructor(PushNotificationsUtils::class)
+        mockkObject(Random)
+        mockkStatic(Task::class)
+        mockkStatic(FirebaseMessaging::class)
+
+        justRun {
+            anyConstructed<PushNotificationsUtils>().showNotification(any(), any(), any())
+        }
+        every { Random.nextInt() } returns TestConst.RANDOM_INT
+        every { anyConstructed<PushNotificationsUtils>().areNotificationsEnabled() } returns true
+
+        every { FirebaseMessaging.getInstance().token } returns mockTask
+        every { mockTask.isSuccessful } returns true
+        every { mockTask.result } returns "foo-bar"
+        every { mockTask.addOnCompleteListener(capture(tokenOnCompleteListenerSlot)) } answers {
+            tokenOnCompleteListenerSlot.captured.onComplete(mockTask)
+            mockTask
+        }
+        val component = ComponentName(context.packageName, "TestMainActivity")
+        shadowOf(context.packageManager).apply {
+            addActivityIfNotPresent(component)
+        }
+    }
+
+    @Test
+    fun `returns permission status`() {
+        val pushPermission = PushNotificationPermission(context)
+
+        every {
+            anyConstructed<PushNotificationPermission>().hasRequiredPermission
+        } returns true
+        assertTrue(pushPermission.hasRequiredPermission)
+
+        every {
+            anyConstructed<PushNotificationPermission>().hasRequiredPermission
+        } returns false
+        assertFalse(pushPermission.hasRequiredPermission)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `requests permission`() = runTest {
+        coEvery {
+            anyConstructed<PushNotificationPermission>().requestPermission()
+        } returns PermissionRequestResult.Granted
+        assertTrue(PushNotificationPermission(context).requestPermission() == PermissionRequestResult.Granted)
+
+        coEvery {
+            anyConstructed<PushNotificationPermission>().requestPermission()
+        } returns PermissionRequestResult.NotGranted(
+            true
+        )
+        assertTrue(
+            PushNotificationPermission(context).requestPermission() == PermissionRequestResult.NotGranted(
+                true
+            )
+        )
+    }
+
+    @Test
+    fun `show notification if enabled`() {
+        InternalPushNotificationUtils(context).showNotification(getTestPayload())
+        verify {
+            anyConstructed<PushNotificationsUtils>().showNotification(
+                TestConst.RANDOM_INT,
+                any(),
+                context.getLaunchActivityClass()
+            )
+        }
+    }
+
+    @Test
+    fun `does not show notification if not enabled`() {
+        every { anyConstructed<PushNotificationsUtils>().areNotificationsEnabled() } returns false
+        InternalPushNotificationUtils(context).showNotification(getTestPayload())
+        verify(exactly = 0) {
+            anyConstructed<PushNotificationsUtils>().showNotification(
+                any(), any(), any()
+            )
+        }
+    }
+
+    @Test
+    fun `does not show notification if explicitly silent`() {
+        InternalPushNotificationUtils(context).showNotification(
+            getTestPayload(
+                mapOf(
+                    PushNotificationsConstants.PINPOINT_NOTIFICATION_SILENTPUSH to "1"
+                )
+            )
+        )
+        verify(exactly = 0) {
+            anyConstructed<PushNotificationsUtils>().showNotification(
+                any(), any(), any()
+            )
+        }
+    }
+
+    @Test
+    fun `builds a notificationId based on campaign attributes`() {
+        InternalPushNotificationUtils(context).showNotification(
+            getTestPayload(
+                mapOf(
+                    PushNotificationsConstants.PINPOINT_CAMPAIGN_CAMPAIGN_ID to TestConst.CAMPAIGN_ID,
+                    PushNotificationsConstants.PINPOINT_CAMPAIGN_CAMPAIGN_ACTIVITY_ID to TestConst.CAMPAIGN_ACTIVITY_ID
+                )
+            )
+        )
+        verify {
+            anyConstructed<PushNotificationsUtils>().showNotification(
+                "${TestConst.CAMPAIGN_ID}:${TestConst.CAMPAIGN_ACTIVITY_ID}".hashCode(),
+                any(),
+                any()
+            )
+        }
+    }
+
+    @Test
+    fun `builds a notificationId based on journey attributes`() {
+        InternalPushNotificationUtils(context).showNotification(
+            getTestPayload(
+                mapOf(
+                    PushNotificationsConstants.PINPOINT_PREFIX to Json.encodeToString(
+                        mapOf(
+                            PushNotificationsConstants.JOURNEY to mapOf(
+                                PushNotificationsConstants.JOURNEY_ID to TestConst.JOURNEY_ID,
+                                PushNotificationsConstants.JOURNEY_ACTIVITY_ID to TestConst.JOURNEY_ACTIVITY_ID
+                            )
+                        )
+                    )
+                )
+            )
+        )
+        verify {
+            anyConstructed<PushNotificationsUtils>().showNotification(
+                "${TestConst.JOURNEY_ID}:${TestConst.JOURNEY_ACTIVITY_ID}".hashCode(), any(), any()
+            )
+        }
+    }
+
+    @Test
+    fun `builds a random notificationId if only campaign id is present`() {
+        InternalPushNotificationUtils(context).showNotification(
+            getTestPayload(
+                mapOf(
+                    PushNotificationsConstants.PINPOINT_CAMPAIGN_CAMPAIGN_ID to TestConst.CAMPAIGN_ID
+                )
+            )
+        )
+        verify {
+            anyConstructed<PushNotificationsUtils>().showNotification(
+                TestConst.RANDOM_INT, any(), any()
+            )
+        }
+    }
+
+    @Test
+    fun `returns if app is in foreground`() {
+        every { anyConstructed<PushNotificationsUtils>().isAppInForeground() } returns true
+        assertTrue(InternalPushNotificationUtils(context).isAppInForeground())
+        every { anyConstructed<PushNotificationsUtils>().isAppInForeground() } returns false
+        assertFalse(InternalPushNotificationUtils(context).isAppInForeground())
+    }
+
+    @Test
+    fun `can create a payload from bundle`() {
+        val bundle = Bundle()
+        bundle.apply {
+            putString(PushNotificationsConstants.PINPOINT_NOTIFICATION_TITLE, TestConst.TITLE)
+            putString(PushNotificationsConstants.PINPOINT_NOTIFICATION_BODY, TestConst.BODY)
+        }
+        val payload = bundle.getNotificationPayload()
+        assertEquals(
+            TestConst.TITLE,
+            payload?.rawData?.get(PushNotificationsConstants.PINPOINT_NOTIFICATION_TITLE)
+        )
+        assertEquals(
+            TestConst.BODY,
+            payload?.rawData?.get(PushNotificationsConstants.PINPOINT_NOTIFICATION_BODY)
+        )
+    }
+
+    @Test
+    fun `can create a writable map from payload`() {
+        val payload = NotificationPayload.Builder(
+            NotificationContentProvider.FCM(
+                mapOf(
+                    PushNotificationsConstants.PINPOINT_NOTIFICATION_TITLE to TestConst.TITLE,
+                    PushNotificationsConstants.PINPOINT_NOTIFICATION_BODY to TestConst.BODY,
+                    PushNotificationsConstants.PINPOINT_NOTIFICATION_IMAGEURL to TestConst.IMAGE_URL,
+                    TestConst.ADHOC_KEY to TestConst.ADHOC_VAL
+                )
+            )
+        ).build()
+        val payloadMap = payload.toWritableMap()
+        val fcmOptions = payloadMap["fcmOptions"] as Map<*,*>
+        val data = payloadMap["data"] as Map<*,*>
+
+        assertEquals(payloadMap["title"], TestConst.TITLE)
+        assertEquals(payloadMap["body"], TestConst.BODY)
+        assertEquals(payloadMap["imageUrl"], TestConst.IMAGE_URL)
+        assertEquals(fcmOptions["channelId"], PushNotificationsConstants.DEFAULT_NOTIFICATION_CHANNEL_ID)
+        assertEquals(data[TestConst.ADHOC_KEY], TestConst.ADHOC_VAL)
+
+    }
+
+    @Test
+    fun `writable map from payload can contain url action`() {
+        val payload = NotificationPayload.Builder(
+            NotificationContentProvider.FCM(mapOf(PushNotificationsConstants.PINPOINT_URL to TestConst.URL))
+        ).build()
+        val payloadMap = payload.toWritableMap()
+        val action = payloadMap["action"] as Map<*, *>
+        assertEquals(action[PushNotificationsConstants.URL], TestConst.URL)
+    }
+
+    @Test
+    fun `writable map from payload can contain deeplink action`() {
+        val payload = NotificationPayload.Builder(
+            NotificationContentProvider.FCM(mapOf(PushNotificationsConstants.PINPOINT_DEEPLINK to TestConst.DEEPLINK_URL))
+        ).build()
+        val payloadMap =  payload.toWritableMap()
+        val action = payloadMap["action"] as Map<*, *>
+        assertEquals(
+            action[PushNotificationsConstants.DEEPLINK],
+            TestConst.DEEPLINK_URL
+        )
+
+    }
+
+    @Test
+    fun `writable map from payload always has data`() {
+        val payload = NotificationPayload.Builder(
+            NotificationContentProvider.FCM(emptyMap())
+        ).build()
+        val payloadMap = payload.toWritableMap()
+
+        assertTrue(payloadMap["data"] is Map<*, *>)
+    }
+
+    @Test
+    fun `refresh token runs successfully`() {
+        StreamHandlers.initStreamHandlers(refresh = true)
+        val mockEventSink = mockk<EventChannel.EventSink>()
+        mockkConstructor(EventChannel.EventSink::class)
+        refreshToken()
+        StreamHandlers.tokenReceived!!.onListen(ArgumentMatchers.any(), mockEventSink)
+        verify(exactly = 1) {
+            mockEventSink.success(any())
+        }
+    }
+
+    @Test
+    fun `refresh token sends error`() {
+        StreamHandlers.initStreamHandlers(refresh = true)
+        val mockEventSink = mockk<EventChannel.EventSink>()
+        mockkConstructor(EventChannel.EventSink::class)
+        every { mockTask.exception } returns Exception("test")
+        every { mockTask.isSuccessful } returns false
+        refreshToken()
+        StreamHandlers.tokenReceived!!.onListen(ArgumentMatchers.any(), mockEventSink)
+        verify(exactly = 1) {
+            mockEventSink.error(any(),any(),any())
+        }
+    }
+
+}

--- a/packages/amplify_push/android/src/test/kotlin/com/amazonaws/amplify/amplify_push_notifications/PushNotificationBackgroundServiceTest.kt
+++ b/packages/amplify_push/android/src/test/kotlin/com/amazonaws/amplify/amplify_push_notifications/PushNotificationBackgroundServiceTest.kt
@@ -1,0 +1,126 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazonaws.amplify.amplify_push_notifications
+
+import android.content.Context
+import android.content.Intent
+import android.content.SharedPreferences
+import android.os.Looper
+import com.amplifyframework.annotations.InternalAmplifyApi
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.embedding.engine.FlutterEngineCache
+import io.flutter.embedding.engine.loader.FlutterLoader
+import io.flutter.plugin.common.MethodChannel
+import io.flutter.view.FlutterCallbackInformation
+import io.mockk.*
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import org.robolectric.android.controller.ServiceController
+
+
+@InternalAmplifyApi
+@RunWith(RobolectricTestRunner::class)
+class PushNotificationBackgroundServiceTest {
+
+    private lateinit var pushNotificationBackgroundService: PushNotificationBackgroundService
+    private lateinit var mockContext: Context
+    private val mockSharedPreferences = mockk<SharedPreferences>()
+    private lateinit var controller: ServiceController<PushNotificationBackgroundService>
+    private lateinit var mockFlutterLoader: FlutterLoader
+
+    @Before
+    fun setUp() {
+        controller =
+            Robolectric.buildService(PushNotificationBackgroundService::class.java, Intent())
+        mockContext = mockk()
+        every {
+            mockContext.getSharedPreferences(
+                PushNotificationPluginConstants.SHARED_PREFERENCES_KEY,
+                Context.MODE_PRIVATE
+            )
+        } returns mockSharedPreferences
+
+        mockFlutterLoader = mockk()
+
+        val mockSharedPreferencesEditor = mockk<SharedPreferences.Editor>()
+        justRun { mockSharedPreferencesEditor.apply() }
+        every { mockSharedPreferences.edit() } returns mockSharedPreferencesEditor
+        every {
+            mockSharedPreferences.getLong(
+                any(), any()
+            )
+        } returns 5555
+
+        val mockFlutterEngine = mockk<FlutterEngine>()
+        mockkConstructor(FlutterEngineCache::class)
+        every {
+            anyConstructed<FlutterEngineCache>()
+                .get(PushNotificationPluginConstants.BACKGROUND_ENGINE_ID)
+        } returns mockFlutterEngine
+
+        every {
+            mockFlutterEngine.dartExecutor.executeDartCallback(any())
+        } returns mockk()
+        every {
+            mockFlutterEngine.dartExecutor.binaryMessenger
+        } returns mockk()
+        mockkStatic(FlutterCallbackInformation::class)
+        val mockFlutterCallbackInformation = mockk<FlutterCallbackInformation>()
+        every {
+            FlutterCallbackInformation.lookupCallbackInformation(any())
+        } returns mockFlutterCallbackInformation
+
+        mockkConstructor(MethodChannel::class)
+        every { anyConstructed<MethodChannel>().setMethodCallHandler(any()) } returns mockk()
+
+        every { mockContext.assets } returns mockk()
+        every { mockFlutterLoader.findAppBundlePath() } returns ""
+        pushNotificationBackgroundService = PushNotificationBackgroundService()
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic(FlutterCallbackInformation::class)
+    }
+
+    @Test
+    fun `should start the background service`() {
+        val mockFlutterEngine = mockk<FlutterEngine>()
+        every {
+            anyConstructed<FlutterEngineCache>()
+                .get(PushNotificationPluginConstants.BACKGROUND_ENGINE_ID)
+        } returns null
+
+        every { mockFlutterEngine.dartExecutor.executeDartCallback(any()) } returns mockk()
+        every { mockFlutterEngine.dartExecutor.binaryMessenger } returns mockk()
+        pushNotificationBackgroundService.createAndRunBackgroundEngine(
+            mockContext,
+            mockFlutterLoader,
+            mockFlutterEngine,
+        )
+        Shadows.shadowOf(Looper.getMainLooper()).idle()
+    }
+
+
+    @Test
+    fun `should throw if background processor function is not found`() {
+        every {
+            FlutterCallbackInformation.lookupCallbackInformation(any())
+        } returns null
+        assertThrows(Exception::class.java) {
+            pushNotificationBackgroundService.createAndRunBackgroundEngine(
+                mockContext,
+                mockFlutterLoader,
+                null,
+            )
+            Shadows.shadowOf(Looper.getMainLooper()).idle()
+        }
+    }
+}

--- a/packages/amplify_push/android/src/test/kotlin/com/amazonaws/amplify/amplify_push_notifications/PushNotificationEventsStreamHandlerTest.kt
+++ b/packages/amplify_push/android/src/test/kotlin/com/amazonaws/amplify/amplify_push_notifications/PushNotificationEventsStreamHandlerTest.kt
@@ -1,0 +1,61 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazonaws.amplify.amplify_push_notifications
+
+import com.amplifyframework.annotations.InternalAmplifyApi
+import io.flutter.plugin.common.BinaryMessenger
+import io.flutter.plugin.common.EventChannel
+import io.flutter.plugin.common.EventChannel.EventSink
+import io.mockk.*
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.any
+import org.robolectric.RobolectricTestRunner
+
+@InternalAmplifyApi
+@RunWith(RobolectricTestRunner::class)
+class PushNotificationEventsStreamHandlerTest {
+
+    @Before
+    fun setUp() {
+        val mockedBinaryMessenger = mockk<BinaryMessenger>()
+        mockkConstructor(EventChannel::class)
+        every { anyConstructed<EventChannel>().setStreamHandler(any()) } returns
+        StreamHandlers.initStreamHandlers(refresh = true)
+        StreamHandlers.initEventChannels(mockedBinaryMessenger)
+    }
+
+    @Test
+    fun `should queue and send event when listener is added`() {
+        val testMap = mapOf<Any, Any?>()
+        val mockEventSink = mockk<EventSink>()
+        mockkConstructor(EventSink::class)
+        StreamHandlers.tokenReceived!!.send(testMap)
+
+        verify(exactly = 0) {
+            mockEventSink.success(any())
+        }
+        StreamHandlers.tokenReceived!!.onListen(any(), mockEventSink)
+        verify(exactly = 1) {
+            mockEventSink.success(any())
+        }
+    }
+
+    @Test
+    fun `should send error event`() {
+        val mockEventSink = mockk<EventSink>()
+        mockkConstructor(EventSink::class)
+        StreamHandlers.tokenReceived!!.sendError(Exception("test"))
+
+        verify(exactly = 0) {
+            mockEventSink.error(any(), any(), any())
+        }
+        StreamHandlers.tokenReceived!!.onListen(any(), mockEventSink)
+        verify(exactly = 1) {
+            mockEventSink.error(any(), "test", any())
+        }
+    }
+}

--- a/packages/amplify_push/android/src/test/kotlin/com/amazonaws/amplify/amplify_push_notifications/PushNotificationFirebaseMessagingServiceTest.kt
+++ b/packages/amplify_push/android/src/test/kotlin/com/amazonaws/amplify/amplify_push_notifications/PushNotificationFirebaseMessagingServiceTest.kt
@@ -1,0 +1,108 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazonaws.amplify.amplify_push_notifications
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.os.Looper.getMainLooper
+import com.amplifyframework.annotations.InternalAmplifyApi
+import com.amplifyframework.notifications.pushnotifications.NotificationContentProvider
+import com.amplifyframework.notifications.pushnotifications.NotificationPayload
+import io.flutter.embedding.engine.loader.FlutterLoader
+import io.flutter.plugin.common.BinaryMessenger
+import io.flutter.plugin.common.EventChannel
+import io.flutter.plugin.common.EventChannel.EventSink
+import io.mockk.*
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers
+import org.robolectric.Robolectric.buildService
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.android.controller.ServiceController
+
+@InternalAmplifyApi
+@RunWith(RobolectricTestRunner::class)
+class PushNotificationFirebaseMessagingServiceTest {
+    private lateinit var context: Context
+    private lateinit var mockEventSink: EventSink
+    private object TestConst {
+        const val TOKEN = "foo-bar"
+    }
+
+    private val testPayload = NotificationPayload.Builder(
+        NotificationContentProvider.FCM(
+            content = mapOf()
+        )
+    ).build()
+    private lateinit var controller: ServiceController<PushNotificationFirebaseMessagingService>
+
+    @Before
+    fun setup() {
+        context = RuntimeEnvironment.getApplication().baseContext
+        val mockedBinaryMessenger = mockk<BinaryMessenger>()
+        mockkConstructor(EventChannel::class)
+        every { anyConstructed<EventChannel>().setStreamHandler(any()) } returns StreamHandlers.initStreamHandlers(
+            refresh = true
+        )
+        StreamHandlers.initEventChannels(mockedBinaryMessenger)
+        mockEventSink = mockk()
+        mockkConstructor(EventSink::class)
+        mockkConstructor(InternalPushNotificationUtils::class)
+        mockkStatic(Bundle::getNotificationPayload)
+        mockkStatic(NotificationPayload::toWritableMap)
+
+        justRun {
+            anyConstructed<InternalPushNotificationUtils>().showNotification(any())
+        }
+        every { any<Bundle>().getNotificationPayload() } returns testPayload
+        controller = buildService(PushNotificationFirebaseMessagingService::class.java, Intent())
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic(Bundle::getNotificationPayload)
+        unmockkStatic(NotificationPayload::toWritableMap)
+    }
+
+    @Test
+    fun `sends token received event on new token`() {
+        controller.create().get().onNewToken(TestConst.TOKEN)
+        shadowOf(getMainLooper()).idle()
+
+        StreamHandlers.tokenReceived!!.onListen(ArgumentMatchers.any(), mockEventSink)
+        verify(exactly = 1) {
+            mockEventSink.success(any())
+        }
+    }
+
+    @Test
+    fun `handles message in foreground`() {
+        context = mockk()
+        every { anyConstructed<InternalPushNotificationUtils>().isAppInForeground() } returns true
+        mockkConstructor(FlutterLoader::class)
+        controller.create().get().handleIntent(Intent())
+        shadowOf(getMainLooper()).idle()
+        StreamHandlers.foregroundMessageReceived!!.onListen(ArgumentMatchers.any(), mockEventSink)
+        verify(exactly = 1) {
+            mockEventSink.success(any())
+        }
+    }
+
+    @Test
+    fun `handles message in background`() {
+        every { anyConstructed<InternalPushNotificationUtils>().isAppInForeground() } returns false
+        controller.create().get().handleIntent(Intent())
+        shadowOf(getMainLooper()).idle()
+
+        verify {
+            anyConstructed<InternalPushNotificationUtils>().showNotification(testPayload)
+        }
+    }
+}

--- a/packages/amplify_push/test/amplify_push_client_test.dart
+++ b/packages/amplify_push/test/amplify_push_client_test.dart
@@ -1,0 +1,260 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_foundation_dart/amplify_foundation_dart.dart';
+import 'package:amplify_push/amplify_push.dart';
+import 'package:amplify_push/src/native_push_plugin.g.dart';
+import 'package:amplify_push/src/push_flutter_api.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'test_data/fake_notification_messages.dart';
+
+class MockHostApi extends Mock implements PushNotificationsHostApi {}
+
+class MockPushServiceProvider extends Mock implements PushServiceProvider {}
+
+class FakePushEvent extends Fake implements PushEvent {}
+
+class FakePermissionsOptions extends Fake implements PermissionsOptions {}
+
+void main() {
+  late MockHostApi mockHostApi;
+  late PushFlutterApi flutterApi;
+
+  setUpAll(() {
+    registerFallbackValue(FakePushEvent());
+    registerFallbackValue(FakePermissionsOptions());
+  });
+
+  setUp(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    SharedPreferences.setMockInitialValues({});
+    PushFlutterApi.reset();
+    AmplifyPushClient.resetForTesting();
+    flutterApi = PushFlutterApi.instance;
+    mockHostApi = MockHostApi();
+  });
+
+  group('AmplifyPushClient.create', () {
+    test('creates client in standalone mode (no provider)', () async {
+      when(() => mockHostApi.requestInitialToken()).thenAnswer((_) async {});
+      when(
+        () => mockHostApi.getLaunchNotification(),
+      ).thenAnswer((_) async => null);
+
+      final result = await AmplifyPushClient.create(
+        hostApi: mockHostApi,
+        flutterApi: flutterApi,
+      );
+
+      switch (result) {
+        case Ok(:final value):
+          expect(value, isA<AmplifyPushClient>());
+        case Error(:final error):
+          fail('Expected Ok, got Error: $error');
+      }
+    });
+
+    test('creates client with provider and registers token', () async {
+      final mockProvider = MockPushServiceProvider();
+      when(() => mockProvider.onTokenReceived(any())).thenAnswer((_) async {});
+      when(() => mockProvider.onPushEvent(any())).thenAnswer((_) async {});
+      when(() => mockHostApi.requestInitialToken()).thenAnswer((_) async {});
+      when(
+        () => mockHostApi.getLaunchNotification(),
+      ).thenAnswer((_) async => null);
+
+      // Note: In a real test we'd need to simulate the token event channel
+      // firing. Since we can't easily do that without the full binding,
+      // the create() will timeout on token wait and log a warning — that's OK.
+      final result = await AmplifyPushClient.create(
+        provider: mockProvider,
+        hostApi: mockHostApi,
+        flutterApi: flutterApi,
+      );
+
+      expect(result, isA<Ok<AmplifyPushClient>>());
+    });
+
+    test('returns launch notification when present', () async {
+      when(() => mockHostApi.requestInitialToken()).thenAnswer((_) async {});
+      when(
+        () => mockHostApi.getLaunchNotification(),
+      ).thenAnswer((_) async => standardAndroidPushMessage.cast());
+
+      final result = await AmplifyPushClient.create(
+        hostApi: mockHostApi,
+        flutterApi: flutterApi,
+      );
+
+      switch (result) {
+        case Ok(:final value):
+          final launch = value.consumeLaunchNotification();
+          expect(launch, isNotNull);
+          expect(launch!.title, 'TITLE');
+          // Consumed on first read
+          expect(value.consumeLaunchNotification(), isNull);
+        case Error(:final error):
+          fail('Expected Ok, got Error: $error');
+      }
+    });
+
+    test('notifies provider of launch notification', () async {
+      final mockProvider = MockPushServiceProvider();
+      when(() => mockProvider.onTokenReceived(any())).thenAnswer((_) async {});
+      when(() => mockProvider.onPushEvent(any())).thenAnswer((_) async {});
+      when(() => mockHostApi.requestInitialToken()).thenAnswer((_) async {});
+      when(
+        () => mockHostApi.getLaunchNotification(),
+      ).thenAnswer((_) async => standardAndroidPushMessage.cast());
+
+      await AmplifyPushClient.create(
+        provider: mockProvider,
+        hostApi: mockHostApi,
+        flutterApi: flutterApi,
+      );
+
+      final captured =
+          verify(() => mockProvider.onPushEvent(captureAny())).captured.single
+              as PushEvent;
+      expect(captured.type, PushEventType.opened);
+      expect(captured.notification.title, 'TITLE');
+    });
+  });
+
+  group('Permission APIs', () {
+    late AmplifyPushClient client;
+
+    setUp(() async {
+      when(() => mockHostApi.requestInitialToken()).thenAnswer((_) async {});
+      when(
+        () => mockHostApi.getLaunchNotification(),
+      ).thenAnswer((_) async => null);
+
+      final result = await AmplifyPushClient.create(
+        hostApi: mockHostApi,
+        flutterApi: flutterApi,
+      );
+      client = (result as Ok<AmplifyPushClient>).value;
+    });
+
+    test('getPermissionStatus returns granted', () async {
+      when(() => mockHostApi.getPermissionStatus()).thenAnswer(
+        (_) async =>
+            GetPermissionStatusResult(status: PermissionStatus.granted),
+      );
+
+      final result = await client.getPermissionStatus();
+      switch (result) {
+        case Ok(:final value):
+          expect(value, PushPermissionStatus.granted);
+        case Error(:final error):
+          fail('Expected Ok, got Error: $error');
+      }
+    });
+
+    test('getPermissionStatus returns denied', () async {
+      when(() => mockHostApi.getPermissionStatus()).thenAnswer(
+        (_) async => GetPermissionStatusResult(status: PermissionStatus.denied),
+      );
+
+      final result = await client.getPermissionStatus();
+      expect((result as Ok).value, PushPermissionStatus.denied);
+    });
+
+    test('requestPermissions returns true when granted', () async {
+      when(
+        () => mockHostApi.requestPermissions(any()),
+      ).thenAnswer((_) async => true);
+
+      final result = await client.requestPermissions();
+      expect((result as Ok).value, isTrue);
+    });
+
+    test('requestPermissions returns false when denied', () async {
+      when(
+        () => mockHostApi.requestPermissions(any()),
+      ).thenAnswer((_) async => false);
+
+      final result = await client.requestPermissions();
+      expect((result as Ok).value, isFalse);
+    });
+  });
+
+  group('Badge count APIs', () {
+    late AmplifyPushClient client;
+
+    setUp(() async {
+      when(() => mockHostApi.requestInitialToken()).thenAnswer((_) async {});
+      when(
+        () => mockHostApi.getLaunchNotification(),
+      ).thenAnswer((_) async => null);
+
+      final result = await AmplifyPushClient.create(
+        hostApi: mockHostApi,
+        flutterApi: flutterApi,
+      );
+      client = (result as Ok<AmplifyPushClient>).value;
+    });
+
+    test('getBadgeCount returns count from native', () async {
+      when(() => mockHostApi.getBadgeCount()).thenAnswer((_) async => 5);
+
+      final result = await client.getBadgeCount();
+      expect((result as Ok).value, 5);
+    });
+
+    test('setBadgeCount calls native', () {
+      when(() => mockHostApi.setBadgeCount(any())).thenAnswer((_) async {});
+
+      client.setBadgeCount(42);
+      verify(() => mockHostApi.setBadgeCount(42)).called(1);
+    });
+  });
+
+  group('Client lifecycle', () {
+    late AmplifyPushClient client;
+
+    setUp(() async {
+      when(() => mockHostApi.requestInitialToken()).thenAnswer((_) async {});
+      when(
+        () => mockHostApi.getLaunchNotification(),
+      ).thenAnswer((_) async => null);
+
+      final result = await AmplifyPushClient.create(
+        hostApi: mockHostApi,
+        flutterApi: flutterApi,
+      );
+      client = (result as Ok<AmplifyPushClient>).value;
+    });
+
+    test('close prevents further operations', () async {
+      await client.close();
+
+      expect(
+        () => client.onTokenReceived,
+        throwsA(isA<PushClientClosedException>()),
+      );
+      expect(
+        () => client.onNotificationReceivedInForeground,
+        throwsA(isA<PushClientClosedException>()),
+      );
+      expect(
+        () => client.onNotificationOpened,
+        throwsA(isA<PushClientClosedException>()),
+      );
+      expect(
+        () => client.consumeLaunchNotification(),
+        throwsA(isA<PushClientClosedException>()),
+      );
+
+      final permResult = await client.getPermissionStatus();
+      expect(permResult, isA<Error<PushPermissionStatus>>());
+
+      final badgeResult = await client.getBadgeCount();
+      expect(badgeResult, isA<Error<int>>());
+    });
+  });
+}

--- a/packages/amplify_push/test/amplify_push_exception_test.dart
+++ b/packages/amplify_push/test/amplify_push_exception_test.dart
@@ -1,0 +1,62 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'dart:async';
+
+import 'package:amplify_push/amplify_push.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AmplifyPushException.from', () {
+    test('returns same instance for AmplifyPushException input', () {
+      const original = PushAlreadyConfiguredException();
+      final result = AmplifyPushException.from(original);
+      expect(identical(result, original), isTrue);
+    });
+
+    test('wraps PlatformException as PushPlatformException', () {
+      final platform = PlatformException(code: 'test');
+      final result = AmplifyPushException.from(platform);
+      expect(result, isA<PushPlatformException>());
+      expect(result.cause, platform);
+    });
+
+    test('wraps TimeoutException as PushTimeoutException', () {
+      final timeout = TimeoutException('timed out');
+      final result = AmplifyPushException.from(timeout);
+      expect(result, isA<PushTimeoutException>());
+      expect(result.cause, timeout);
+    });
+
+    test('wraps unknown Exception as PushUnknownException', () {
+      const unknown = FormatException('bad');
+      final result = AmplifyPushException.from(unknown);
+      expect(result, isA<PushUnknownException>());
+      expect(result.cause, unknown);
+    });
+
+    test('wraps non-Exception as PushUnknownException', () {
+      final result = AmplifyPushException.from('string error');
+      expect(result, isA<PushUnknownException>());
+    });
+  });
+
+  group('Exception messages', () {
+    test('PushAlreadyConfiguredException has correct message', () {
+      const e = PushAlreadyConfiguredException();
+      expect(e.message, contains('already exists'));
+      expect(e.recoverySuggestion, contains('close()'));
+    });
+
+    test('PushClientClosedException has correct message', () {
+      const e = PushClientClosedException();
+      expect(e.message, contains('closed'));
+    });
+
+    test('PushCallbackException has correct message', () {
+      const e = PushCallbackException();
+      expect(e.message, contains('not a global or static'));
+    });
+  });
+}

--- a/packages/amplify_push/test/push_flutter_api_test.dart
+++ b/packages/amplify_push/test/push_flutter_api_test.dart
@@ -1,0 +1,94 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_push/amplify_push.dart';
+import 'package:amplify_push/src/push_flutter_api.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'test_data/fake_notification_messages.dart';
+
+class MockPushServiceProvider extends Mock implements PushServiceProvider {}
+
+class FakePushEvent extends Fake implements PushEvent {}
+
+void main() {
+  late PushFlutterApi flutterApi;
+  late MockPushServiceProvider mockProvider;
+
+  setUpAll(() {
+    registerFallbackValue(FakePushEvent());
+  });
+
+  setUp(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    SharedPreferences.setMockInitialValues({});
+    PushFlutterApi.reset();
+    flutterApi = PushFlutterApi.instance;
+    mockProvider = MockPushServiceProvider();
+  });
+
+  test('dispatches background notification to provider', () async {
+    when(() => mockProvider.onPushEvent(any())).thenAnswer((_) async {});
+    flutterApi.provider = mockProvider;
+
+    await flutterApi.onNotificationReceivedInBackground(
+      standardAndroidPushMessage.cast(),
+    );
+
+    final captured =
+        verify(() => mockProvider.onPushEvent(captureAny())).captured.single
+            as PushEvent;
+    expect(captured.type, PushEventType.backgroundReceived);
+    expect(captured.notification.title, 'TITLE');
+  });
+
+  test('dispatches to registered iOS background callbacks', () async {
+    PushNotificationMessage? received;
+    flutterApi.registerBackgroundCallback((msg) async {
+      received = msg;
+    });
+
+    await flutterApi.onNotificationReceivedInBackground(
+      standardAndroidPushMessage.cast(),
+    );
+
+    expect(received, isNotNull);
+    expect(received!.title, 'TITLE');
+  });
+
+  test('works without provider (standalone mode)', () async {
+    // No provider set — should not throw
+    await flutterApi.onNotificationReceivedInBackground(
+      standardAndroidPushMessage.cast(),
+    );
+    // If we get here without exception, standalone mode works
+  });
+
+  test('provider error does not prevent callback dispatch', () async {
+    when(() => mockProvider.onPushEvent(any())).thenThrow(Exception('fail'));
+    flutterApi.provider = mockProvider;
+
+    PushNotificationMessage? received;
+    flutterApi.registerBackgroundCallback((msg) async {
+      received = msg;
+    });
+
+    await flutterApi.onNotificationReceivedInBackground(
+      standardAndroidPushMessage.cast(),
+    );
+
+    // Callback still fired despite provider error
+    expect(received, isNotNull);
+    expect(received!.title, 'TITLE');
+  });
+
+  test('nullifyLaunchNotification calls registered callback', () {
+    var called = false;
+    flutterApi.onNullifyLaunchNotification = () => called = true;
+    // ignore: cascade_invocations
+    flutterApi.nullifyLaunchNotification();
+    expect(called, isTrue);
+  });
+}

--- a/packages/amplify_push/test/push_notification_message_test.dart
+++ b/packages/amplify_push/test/push_notification_message_test.dart
@@ -1,0 +1,57 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_push/amplify_push.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'test_data/fake_notification_messages.dart';
+
+void main() {
+  group('PushNotificationMessage.fromJson', () {
+    test('parses standard Android message with title, body, channelId', () {
+      final msg = PushNotificationMessage.fromJson(
+        standardAndroidPushMessage.cast(),
+      );
+      expect(msg.title, 'TITLE');
+      expect(msg.body, 'BODY');
+      expect(msg.fcmOptions?.channelId, 'DEFAULT_CHANNEL');
+    });
+
+    test('parses simple iOS alert string', () {
+      final msg = PushNotificationMessage.fromJson(
+        simpleAlertiOSMessage.cast(),
+      );
+      expect(msg.title, 'Hello, world');
+    });
+
+    test('parses standard iOS message with title and body', () {
+      final msg = PushNotificationMessage.fromJson(standardiOSMessage.cast());
+      expect(msg.title, 'TITLE');
+      expect(msg.body, 'BODY');
+    });
+
+    test('parses url and deeplink from Android', () {
+      final msg = PushNotificationMessage.fromJson(urlsAndroidMessage.cast());
+      expect(msg.goToUrl, 'URL');
+      expect(msg.deeplinkUrl, 'DEEPLINK');
+    });
+
+    test('parses deeplink from iOS', () {
+      final msg = PushNotificationMessage.fromJson(urlsiOSMessage.cast());
+      expect(msg.deeplinkUrl, 'URL');
+      expect(msg.goToUrl, isNull);
+    });
+
+    test('parses imageUrl from Android', () {
+      final msg = PushNotificationMessage.fromJson(
+        imageUrlAndroidPushMessage.cast(),
+      );
+      expect(msg.imageUrl, 'TEST_URL');
+    });
+
+    test('parses imageUrl from iOS', () {
+      final msg = PushNotificationMessage.fromJson(imageUrliOSMessage.cast());
+      expect(msg.imageUrl, 'TEST_URL');
+    });
+  });
+}

--- a/packages/amplify_push/test/test_data/fake_notification_messages.dart
+++ b/packages/amplify_push/test/test_data/fake_notification_messages.dart
@@ -1,0 +1,66 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Erase types on maps to mimic how maps come back from the platform.
+Map<Object?, Object?> _eraseTypes(Map<Object?, Object?> map) => {
+  for (final MapEntry(:key, :value) in map.entries)
+    key: switch (value) {
+      final Map<Object?, Object?> map => _eraseTypes(map),
+      _ => value,
+    },
+};
+
+final standardAndroidPushMessage = _eraseTypes({
+  'title': 'TITLE',
+  'body': 'BODY',
+  'imageUrl': null,
+  'fcmOptions': {'channelId': 'DEFAULT_CHANNEL'},
+  'action': {'openApp': true, 'url': null, 'deeplink': null},
+  'data': {},
+});
+
+final urlsAndroidMessage = _eraseTypes({
+  'title': 'TITLE',
+  'body': 'BODY',
+  'imageUrl': null,
+  'fcmOptions': {'channelId': 'DEFAULT_CHANNEL'},
+  'action': {'openApp': null, 'url': 'URL', 'deeplink': 'DEEPLINK'},
+  'data': {},
+});
+
+final imageUrlAndroidPushMessage = _eraseTypes({
+  'title': 'TITLE',
+  'body': 'BODY',
+  'imageUrl': 'TEST_URL',
+  'fcmOptions': {'channelId': 'DEFAULT_CHANNEL'},
+  'action': {'openApp': true, 'url': null, 'deeplink': null},
+  'data': {},
+});
+
+final standardiOSMessage = _eraseTypes({
+  'aps': {
+    'alert': {'title': 'TITLE', 'body': 'BODY'},
+    'mutable-content': 0,
+    'content-available': 1,
+  },
+  'data': {},
+});
+
+final simpleAlertiOSMessage = _eraseTypes({
+  'aps': {'alert': 'Hello, world'},
+  'data': {},
+});
+
+final imageUrliOSMessage = _eraseTypes({
+  'data': {'media-url': 'TEST_URL'},
+  'aps': {
+    'alert': {'title': 'TITLE', 'body': 'BODY'},
+  },
+});
+
+final urlsiOSMessage = _eraseTypes({
+  'data': {'deeplink': 'URL'},
+  'aps': {
+    'alert': {'title': 'TITLE', 'body': 'BODY'},
+  },
+});


### PR DESCRIPTION
Unit tests for `amplify_push`, split out for review scoping. **Stacked on #6985** (targets `feat/amplify-push-v3`), so the diff shows only the test files; rebased onto `main` once #6985 merges.

- Dart unit tests (client, flutter API, exception mapping, message parsing)
- Android (Kotlin) unit tests (plugin, background service, stream handler, notification utils, Firebase messaging)

Verified locally: 31 Dart tests pass; analyzer clean. (Android unit tests run in CI on `main` once the example + tests coexist.)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.