### PR TITLE
feat(aft): Locate package by name or tag

### DIFF
--- a/packages/aft/lib/aft.dart
+++ b/packages/aft/lib/aft.dart
@@ -14,6 +14,7 @@ export 'src/commands/generate/generate_command.dart';
 export 'src/commands/get_release_notes_command.dart';
 export 'src/commands/link_command.dart';
 export 'src/commands/list_packages_command.dart';
+export 'src/commands/locate_package_command.dart';
 export 'src/commands/publish_command.dart';
 export 'src/commands/run_command.dart';
 export 'src/commands/serve_command.dart';

--- a/packages/aft/lib/src/command_runner.dart
+++ b/packages/aft/lib/src/command_runner.dart
@@ -23,6 +23,7 @@ Future<void> run(List<String> args) async {
     ..addCommand(GenerateCommand())
     ..addCommand(GetReleaseNotesCommand())
     ..addCommand(ListPackagesCommand())
+    ..addCommand(LocatePackageCommand())
     ..addCommand(ConstraintsCommand())
     ..addCommand(LinkCommand())
     ..addCommand(CleanCommand())

--- a/packages/aft/lib/src/commands/locate_package_command.dart
+++ b/packages/aft/lib/src/commands/locate_package_command.dart
@@ -25,10 +25,12 @@ class LocatePackageCommand extends AmplifyCommand {
     if (!verbose) {
       AWSLogger().logLevel = LogLevel.warn;
     }
+    // Called only to satisfy `@mustCallSuper`; its Repo.open / GitDir.fromExisting
+    // git setup is unused here and can fail in shallow or sparse checkouts.
     await super.run();
 
     final rest = argResults!.rest;
-    if (rest.length != 1 || rest.single.isEmpty) {
+    if (rest.length != 1 || rest.single.trim().isEmpty) {
       usageException('Expected exactly one argument: <name-or-tag>');
     }
     final nameOrTag = rest.single;

--- a/packages/aft/lib/src/commands/locate_package_command.dart
+++ b/packages/aft/lib/src/commands/locate_package_command.dart
@@ -1,0 +1,43 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'dart:io';
+
+import 'package:aft/aft.dart';
+import 'package:aws_common/aws_common.dart';
+import 'package:path/path.dart' as p;
+
+/// Prints the repo-relative path of a package identified by name or publish
+/// tag, e.g. `aft locate-package amplify_core-v2.10.1` -> `packages/amplify_core`.
+class LocatePackageCommand extends AmplifyCommand {
+  @override
+  String get description =>
+      'Prints the repo-relative path of a package by name or publish tag.';
+
+  @override
+  String get name => 'locate-package';
+
+  @override
+  Future<void> run() async {
+    // Reserve stdout for the package path so it can be captured directly,
+    // e.g. `PKG=$(aft locate-package amplify_core-v2.10.1)`. `--verbose`
+    // re-enables the default logging.
+    if (!verbose) {
+      AWSLogger().logLevel = LogLevel.warn;
+    }
+    await super.run();
+
+    final rest = argResults!.rest;
+    if (rest.length != 1 || rest.single.isEmpty) {
+      usageException('Expected exactly one argument: <name-or-tag>');
+    }
+    final nameOrTag = rest.single;
+
+    final package = aftConfig.locatePackage(nameOrTag);
+    if (package == null) {
+      exitError("Error: package '$nameOrTag' not found in workspace");
+    }
+
+    stdout.writeln(p.relative(package.path, from: rootDir.path));
+  }
+}

--- a/packages/aft/lib/src/config/config.dart
+++ b/packages/aft/lib/src/config/config.dart
@@ -96,6 +96,21 @@ abstract class AftConfig
         packageName;
   }
 
+  /// Locates the package identified by [nameOrTag] in [allPackages].
+  ///
+  /// [nameOrTag] may be a package name (`amplify_core`) or a publish tag of
+  /// the form `$name-v$version` as emitted by `aft publish --tags`
+  /// (`amplify_core-v2.10.1`); the trailing `-v$version` is stripped to recover
+  /// the name. Anchoring on `-v` + a digit (never `_v`) leaves names like
+  /// `aws_signature_v4` intact.
+  ///
+  /// Throws if no such package exists, matching the `Repo` `[]` operator.
+  PackageInfo locatePackage(String nameOrTag) {
+    final name =
+        _packageTagPattern.firstMatch(nameOrTag)?.group(1) ?? nameOrTag;
+    return allPackages[name]!;
+  }
+
   @override
   String get runtimeTypeName => 'AftConfig';
 
@@ -485,3 +500,8 @@ final Version activeDartSdkVersion = () {
 }();
 
 final _versionRegex = RegExp(r'\d+\.\d+\.\d+(-[a-zA-Z\d]+)?');
+
+// Captures the package name from a `$name-v$version` publish tag. The `\d`
+// after `-v` anchors on the version, so `_v` in names like `aws_signature_v4`
+// is not treated as a separator. Lazy `.+?` matches the first `-v<digit>`.
+final _packageTagPattern = RegExp(r'^(.+?)-v\d');

--- a/packages/aft/lib/src/config/config.dart
+++ b/packages/aft/lib/src/config/config.dart
@@ -96,19 +96,18 @@ abstract class AftConfig
         packageName;
   }
 
-  /// Locates the package identified by [nameOrTag] in [allPackages].
+  /// Locates the package identified by [nameOrTag] in [allPackages], or `null`
+  /// if no matching package exists.
   ///
   /// [nameOrTag] may be a package name (`amplify_core`) or a publish tag of
   /// the form `$name-v$version` as emitted by `aft publish --tags`
   /// (`amplify_core-v2.10.1`); the trailing `-v$version` is stripped to recover
   /// the name. Anchoring on `-v` + a digit (never `_v`) leaves names like
   /// `aws_signature_v4` intact.
-  ///
-  /// Throws if no such package exists, matching the `Repo` `[]` operator.
-  PackageInfo locatePackage(String nameOrTag) {
+  PackageInfo? locatePackage(String nameOrTag) {
     final name =
         _packageTagPattern.firstMatch(nameOrTag)?.group(1) ?? nameOrTag;
-    return allPackages[name]!;
+    return allPackages[name];
   }
 
   @override

--- a/packages/aft/lib/src/config/config.dart
+++ b/packages/aft/lib/src/config/config.dart
@@ -500,7 +500,5 @@ final Version activeDartSdkVersion = () {
 
 final _versionRegex = RegExp(r'\d+\.\d+\.\d+(-[a-zA-Z\d]+)?');
 
-// Captures the package name from a `$name-v$version` publish tag. The `\d`
-// after `-v` anchors on the version, so `_v` in names like `aws_signature_v4`
-// is not treated as a separator. Lazy `.+?` matches the first `-v<digit>`.
+// Strips the -v<version> suffix; anchoring on a digit avoids splitting _v in names like aws_signature_v4.
 final _packageTagPattern = RegExp(r'^(.+?)-v\d');

--- a/packages/aft/test/config/config_loader_test.dart
+++ b/packages/aft/test/config/config_loader_test.dart
@@ -120,17 +120,17 @@ aft:
   group('locatePackage', () {
     late AftConfig config;
 
-    setUp(() async {
-      d.Descriptor package(String name, String version) => d.dir(name, [
-        d.file('pubspec.yaml', '''
+    d.Descriptor package(String name, String version) => d.dir(name, [
+      d.file('pubspec.yaml', '''
 name: $name
 version: $version
 
 environment:
   sdk: ^3.9.0
 '''),
-      ]);
+    ]);
 
+    setUp(() async {
       await d.dir('repo', [
         d.file('pubspec.yaml', '''
 name: my_repo
@@ -184,6 +184,10 @@ environment:
 
     test('returns null for an unknown package', () {
       check(config.locatePackage('does_not_exist')).isNull();
+    });
+
+    test('treats a tag-like string without -v<digit> as a plain name', () {
+      check(config.locatePackage('amplify_core-vbeta')).isNull();
     });
   });
 }

--- a/packages/aft/test/config/config_loader_test.dart
+++ b/packages/aft/test/config/config_loader_test.dart
@@ -3,6 +3,7 @@
 
 import 'dart:io';
 
+import 'package:aft/src/config/config.dart';
 import 'package:aft/src/config/config_loader.dart';
 import 'package:checks/checks.dart';
 import 'package:path/path.dart' as p;
@@ -113,6 +114,76 @@ aft:
             ..containsKey('license')
             ..containsKey('format'),
         );
+    });
+  });
+
+  group('locatePackage', () {
+    late AftConfig config;
+
+    setUp(() async {
+      d.Descriptor package(String name, String version) => d.dir(name, [
+        d.file('pubspec.yaml', '''
+name: $name
+version: $version
+
+environment:
+  sdk: ^3.9.0
+'''),
+      ]);
+
+      await d.dir('repo', [
+        d.file('pubspec.yaml', '''
+name: my_repo
+publish_to: none
+
+environment:
+  sdk: ^3.9.0
+'''),
+        d.dir('packages', [
+          package('amplify_core', '2.10.1'),
+          package('aws_common', '0.7.6'),
+          package('aws_signature_v4', '0.7.1'),
+        ]),
+      ]).create();
+
+      config = AftConfigLoader(
+        workingDirectory: Directory(p.normalize(d.path('repo'))),
+      ).load();
+    });
+
+    test('resolves a plain package name to its path', () {
+      check(
+        p.normalize(config.locatePackage('amplify_core').path),
+      ).equals(p.normalize(d.path('repo/packages/amplify_core')));
+    });
+
+    test('resolves a tag to the same path as the plain name', () {
+      check(
+        config.locatePackage('amplify_core-v2.10.1').path,
+      ).equals(config.locatePackage('amplify_core').path);
+    });
+
+    test('resolves a name containing `_v` by name and by tag', () {
+      final expectedPath = p.normalize(
+        d.path('repo/packages/aws_signature_v4'),
+      );
+
+      // The `_v4` in the plain name is not mistaken for a tag separator.
+      check(config.locatePackage('aws_signature_v4'))
+        ..has((pkg) => pkg.name, 'name').equals('aws_signature_v4')
+        ..has((pkg) => p.normalize(pkg.path), 'path').equals(expectedPath);
+
+      // The tag form strips only the trailing `-v0.7.1`, not `_v4`.
+      check(config.locatePackage('aws_signature_v4-v0.7.1'))
+        ..has((pkg) => pkg.name, 'name').equals('aws_signature_v4')
+        ..has((pkg) => p.normalize(pkg.path), 'path').equals(expectedPath);
+    });
+
+    test('throws for an unknown package, like the `Repo` `[]` operator', () {
+      expect(
+        () => config.locatePackage('does_not_exist'),
+        throwsA(isA<TypeError>()),
+      );
     });
   });
 }

--- a/packages/aft/test/config/config_loader_test.dart
+++ b/packages/aft/test/config/config_loader_test.dart
@@ -152,15 +152,18 @@ environment:
     });
 
     test('resolves a plain package name to its path', () {
-      check(
-        p.normalize(config.locatePackage('amplify_core').path),
-      ).equals(p.normalize(d.path('repo/packages/amplify_core')));
+      check(config.locatePackage('amplify_core'))
+          .isNotNull()
+          .has((pkg) => p.normalize(pkg.path), 'path')
+          .equals(p.normalize(d.path('repo/packages/amplify_core')));
     });
 
     test('resolves a tag to the same path as the plain name', () {
+      final byName = config.locatePackage('amplify_core');
+      check(byName).isNotNull();
       check(
-        config.locatePackage('amplify_core-v2.10.1').path,
-      ).equals(config.locatePackage('amplify_core').path);
+        config.locatePackage('amplify_core-v2.10.1'),
+      ).isNotNull().has((pkg) => pkg.path, 'path').equals(byName!.path);
     });
 
     test('resolves a name containing `_v` by name and by tag', () {
@@ -169,21 +172,18 @@ environment:
       );
 
       // The `_v4` in the plain name is not mistaken for a tag separator.
-      check(config.locatePackage('aws_signature_v4'))
+      check(config.locatePackage('aws_signature_v4')).isNotNull()
         ..has((pkg) => pkg.name, 'name').equals('aws_signature_v4')
         ..has((pkg) => p.normalize(pkg.path), 'path').equals(expectedPath);
 
       // The tag form strips only the trailing `-v0.7.1`, not `_v4`.
-      check(config.locatePackage('aws_signature_v4-v0.7.1'))
+      check(config.locatePackage('aws_signature_v4-v0.7.1')).isNotNull()
         ..has((pkg) => pkg.name, 'name').equals('aws_signature_v4')
         ..has((pkg) => p.normalize(pkg.path), 'path').equals(expectedPath);
     });
 
-    test('throws for an unknown package, like the `Repo` `[]` operator', () {
-      expect(
-        () => config.locatePackage('does_not_exist'),
-        throwsA(isA<TypeError>()),
-      );
+    test('returns null for an unknown package', () {
+      check(config.locatePackage('does_not_exist')).isNull();
     });
   });
 }


### PR DESCRIPTION
This feature allows to locate a package by name or tag. It's mainly for being used in CI/CD.