### PR TITLE
feat(aft): Await published version on pub.dev before awaiting analysis

### DIFF
--- a/packages/aft/lib/src/commands/amplify_command.dart
+++ b/packages/aft/lib/src/commands/amplify_command.dart
@@ -226,6 +226,24 @@ abstract class AmplifyCommand extends Command<void>
     }
   }
 
+  /// Waits until [version] of [package] is live on `pub.dev`, so its analysis
+  /// has started before we await it.
+  Future<void> awaitPublishedVersion(String package, Version version) async {
+    final qaDurations = Platform.environment.containsKey('QA_DURATIONS');
+
+    final pollInterval = qaDurations
+        ? const Duration(seconds: 1)
+        : const Duration(seconds: 15);
+
+    while (true) {
+      final versionInfo = await resolveVersionInfo(package);
+      if (versionInfo?.allVersions.contains(version) ?? false) {
+        return;
+      }
+      await Future<void>.delayed(pollInterval);
+    }
+  }
+
   @override
   @mustCallSuper
   Future<void> run() async {

--- a/packages/aft/lib/src/publish_scheduler.dart
+++ b/packages/aft/lib/src/publish_scheduler.dart
@@ -224,7 +224,9 @@ class PublishScheduler {
   /// order and call [_publishPackage] for each one.
   Future<void> _runDryRun() async {
     for (final package in _packages) {
-      stdout.writeln('Publishing ${package.name} (${package.version}) [dry run]');
+      stdout.writeln(
+        'Publishing ${package.name} (${package.version}) [dry run]',
+      );
       await _publishPackage(package);
       stdout.writeln('');
     }
@@ -274,15 +276,22 @@ class PublishScheduler {
       await _publishPackage(package);
       published.add(package.name);
 
-      // Kick off analysis in the background. When it completes, update
-      // the adjacency lists and potentially enqueue new packages.
+      // Await the published version, then its analysis, in the background.
+      // When analysis completes, update the adjacency lists and potentially
+      // enqueue new packages.
       final packageName = package.name;
-      final analysisFuture = _command.awaitPendingAnalysis(packageName).then((
-        _,
-      ) {
-        _markAnalysisComplete(adjacencyLists, packageName, published, enqueued);
-        completedAnalyses.add(packageName);
-      });
+      final analysisFuture = _command
+          .awaitPublishedVersion(packageName, package.version)
+          .then((_) => _command.awaitPendingAnalysis(packageName))
+          .then((_) {
+            _markAnalysisComplete(
+              adjacencyLists,
+              packageName,
+              published,
+              enqueued,
+            );
+            completedAnalyses.add(packageName);
+          });
       pendingAnalyses[packageName] = analysisFuture;
     }
 


### PR DESCRIPTION
With this change, we first await the package and then the analysis. Useful when the pending state does not start directly after kicking off publishing.