### PR TITLE
chore: Bump Flutter version and stabilize Windows workflows

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Dart
         uses: dart-lang/setup-dart@43c102f4dc9b9829c862401f0b64c7c9184eab4e # main
         with:
-          sdk: 3.10.0
+          sdk: 3.11.0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # 4.4.0
@@ -63,7 +63,7 @@ jobs:
       - name: Setup Dart
         uses: dart-lang/setup-dart@43c102f4dc9b9829c862401f0b64c7c9184eab4e # main
         with:
-          sdk: 3.10.0
+          sdk: 3.11.0
 
       - name: Setup aft
         shell: bash # Run in bash regardless of platform

--- a/.github/workflows/amplify_canaries.yaml
+++ b/.github/workflows/amplify_canaries.yaml
@@ -31,7 +31,7 @@ jobs:
           - "any" # latest
         include:
           - channel: "stable"
-            flutter-version: "3.38.1"
+            flutter-version: "3.41.0"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
         with:
@@ -87,7 +87,7 @@ jobs:
           - "any" # latest
         include:
           - channel: "stable"
-            flutter-version: "3.38.1"
+            flutter-version: "3.41.0"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
         with:
@@ -162,7 +162,7 @@ jobs:
           - "any" # latest
         include:
           - channel: "stable"
-            flutter-version: "3.38.1"
+            flutter-version: "3.41.0"
         ios-version:
           - "15.0"
           - "17.5"

--- a/.github/workflows/dart_dart2js.yaml
+++ b/.github/workflows/dart_dart2js.yaml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         sdk:
           # Minimum supported Dart version
-          - "3.10.0"
+          - "3.11.0"
           - stable
           - beta
         browser:

--- a/.github/workflows/dart_dart2wasm.yaml
+++ b/.github/workflows/dart_dart2wasm.yaml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         sdk:
           # Minimum supported Dart version
-          - "3.10.0"
+          - "3.11.0"
           - stable
           - beta
         browser:

--- a/.github/workflows/dart_ddc.yaml
+++ b/.github/workflows/dart_ddc.yaml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         sdk:
           # Minimum supported Dart version
-          - "3.10.0"
+          - "3.11.0"
           - stable
           - beta
         browser:

--- a/.github/workflows/dart_native.yaml
+++ b/.github/workflows/dart_native.yaml
@@ -40,6 +40,17 @@ jobs:
       - name: Enable Long Git Paths
         run: git config --system core.longpaths true
 
+      - name: Mitigate Windows Network & Disk Bottlenecks
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: |
+          # 1. Force disable real-time monitoring for the job duration
+          Set-MpPreference -DisableRealtimeMonitoring $true -ErrorAction SilentlyContinue
+          # 2. Exclude your exact workspace path from active scans
+          Set-MpPreference -ExclusionPath "${{ github.workspace }}" -ErrorAction SilentlyContinue
+          # 3. Aggressively lower TCP timed-out port reuse limits (helps local socket recycling)
+          Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters' -Name 'TcpTimedWaitDelay' -Value 30 -ErrorAction SilentlyContinue
+
       - name: Git Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
 

--- a/.github/workflows/dart_vm.yaml
+++ b/.github/workflows/dart_vm.yaml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         sdk:
           # Minimum supported Dart version
-          - "3.10.0"
+          - "3.11.0"
           - stable
           - beta
         # Skips 'beta' tests on PRs

--- a/.github/workflows/e2e_windows.yaml
+++ b/.github/workflows/e2e_windows.yaml
@@ -34,6 +34,16 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - name: Mitigate Windows Network & Disk Bottlenecks
+        shell: powershell
+        run: |
+          # 1. Force disable real-time monitoring for the job duration
+          Set-MpPreference -DisableRealtimeMonitoring $true -ErrorAction SilentlyContinue
+          # 2. Exclude your exact workspace path from active scans
+          Set-MpPreference -ExclusionPath "${{ github.workspace }}" -ErrorAction SilentlyContinue
+          # 3. Aggressively lower TCP timed-out port reuse limits (helps local socket recycling)
+          Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters' -Name 'TcpTimedWaitDelay' -Value 30 -ErrorAction SilentlyContinue
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
         with:
           persist-credentials: false

--- a/.github/workflows/flutter_vm.yaml
+++ b/.github/workflows/flutter_vm.yaml
@@ -30,7 +30,7 @@ jobs:
           - "any" # latest
         include:
           - channel: "stable"
-            flutter-version: "3.38.1"
+            flutter-version: "3.41.0"
         # Skips 'beta' tests on PRs
         exclude:
           - channel: ${{ (github.event_name == 'pull_request') && 'beta' || 'NONE' }}

--- a/actions/pubspec.yaml
+++ b/actions/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   aws_common: ^0.6.1

--- a/canaries/pubspec.yaml
+++ b/canaries/pubspec.yaml
@@ -4,8 +4,8 @@ publish_to: none
 version: 1.0.0+0
 
 environment:
-  sdk: ^3.10.0
-  flutter: ">=3.38.1"
+  sdk: ^3.11.0
+  flutter: ">=3.41.0"
 
 dependencies:
   amplify_analytics_pinpoint: ^2.0.0

--- a/infra-gen2/pubspec.yaml
+++ b/infra-gen2/pubspec.yaml
@@ -2,7 +2,7 @@ name: infra_gen2
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   amplify_core: any

--- a/infra/pubspec.yaml
+++ b/infra/pubspec.yaml
@@ -2,7 +2,7 @@ name: infra
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   amplify_core: any

--- a/packages/aft/pubspec.yaml
+++ b/packages/aft/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.2.3
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   args: ^2.5.0

--- a/packages/amplify/amplify_flutter/example/pubspec.yaml
+++ b/packages/amplify/amplify_flutter/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the Amplify Flutter client libraries.
 publish_to: none
 
 environment:
-  flutter: ">=3.38.1"
-  sdk: ^3.10.0
+  flutter: ">=3.41.0"
+  sdk: ^3.11.0
 
 dependencies:
   amplify_analytics_pinpoint: ">=1.0.0-next.8 <1.0.0-next.9"

--- a/packages/amplify/amplify_flutter/pubspec.yaml
+++ b/packages/amplify/amplify_flutter/pubspec.yaml
@@ -6,8 +6,8 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/am
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.10.0
-  flutter: ">=3.38.1"
+  sdk: ^3.11.0
+  flutter: ">=3.41.0"
 
 # Helps `pana` since we do not use Flutter plugins for most platforms
 platforms:

--- a/packages/amplify_core/doc/pubspec.yaml
+++ b/packages/amplify_core/doc/pubspec.yaml
@@ -7,8 +7,8 @@ issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
-  flutter: ">=3.38.1"
+  sdk: ^3.11.0
+  flutter: ">=3.41.0"
 
 dependencies:
   amplify_analytics_pinpoint: any

--- a/packages/amplify_core/pubspec.yaml
+++ b/packages/amplify_core/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/am
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   async: ^2.10.0

--- a/packages/amplify_datastore/example/pubspec.yaml
+++ b/packages/amplify_datastore/example/pubspec.yaml
@@ -6,8 +6,8 @@ description: Demonstrates how to use the amplify_datastore plugin.
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: ^3.10.0
-  flutter: ">=3.38.1"
+  sdk: ^3.11.0
+  flutter: ">=3.41.0"
 
 dependencies:
   flutter:

--- a/packages/amplify_datastore/pubspec.yaml
+++ b/packages/amplify_datastore/pubspec.yaml
@@ -6,8 +6,8 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/am
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.10.0
-  flutter: ">=3.38.1"
+  sdk: ^3.11.0
+  flutter: ">=3.41.0"
 
 dependencies:
   flutter:

--- a/packages/amplify_datastore_plugin_interface/pubspec.yaml
+++ b/packages/amplify_datastore_plugin_interface/pubspec.yaml
@@ -6,8 +6,8 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/am
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.10.0
-  flutter: ">=3.38.1"
+  sdk: ^3.11.0
+  flutter: ">=3.41.0"
 
 dependencies:
   amplify_core: ">=2.12.0 <2.13.0"

--- a/packages/amplify_foundation/amplify_foundation_dart/pubspec.yaml
+++ b/packages/amplify_foundation/amplify_foundation_dart/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/am
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   json_annotation: ^4.9.0

--- a/packages/amplify_foundation/amplify_foundation_dart_bridge/pubspec.yaml
+++ b/packages/amplify_foundation/amplify_foundation_dart_bridge/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/am
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   amplify_foundation_dart: ">=2.12.0 <2.13.0"

--- a/packages/amplify_lints/pubspec.yaml
+++ b/packages/amplify_lints/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/am
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   flutter_lints: ^6.0.0

--- a/packages/amplify_native_legacy_wrapper/example/pubspec.yaml
+++ b/packages/amplify_native_legacy_wrapper/example/pubspec.yaml
@@ -4,8 +4,8 @@ version: 0.1.0
 publish_to: "none"
 
 environment:
-  sdk: ^3.10.0
-  flutter: ">=3.38.1"
+  sdk: ^3.11.0
+  flutter: ">=3.41.0"
 
 dependencies:
   amplify_native_legacy_wrapper: ^0.1.0

--- a/packages/amplify_native_legacy_wrapper/pubspec.yaml
+++ b/packages/amplify_native_legacy_wrapper/pubspec.yaml
@@ -4,8 +4,8 @@ version: 0.0.1
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
-  flutter: ">=3.38.1"
+  sdk: ^3.11.0
+  flutter: ">=3.41.0"
 
 dependencies:
   flutter:

--- a/packages/analytics/amplify_analytics_pinpoint/example/pubspec.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint/example/pubspec.yaml
@@ -7,8 +7,8 @@ version: 0.1.0
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: ^3.10.0
-  flutter: ">=3.38.1"
+  sdk: ^3.11.0
+  flutter: ">=3.41.0"
 
 dependencies:
   amplify_analytics_pinpoint: ">=1.0.0-next.8 <1.0.0-next.9"

--- a/packages/analytics/amplify_analytics_pinpoint/pubspec.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint/pubspec.yaml
@@ -6,8 +6,8 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/an
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.10.0
-  flutter: ">=3.38.1"
+  sdk: ^3.11.0
+  flutter: ">=3.41.0"
 
 # Helps `pana` since we do not use Flutter plugins for most platforms
 platforms:

--- a/packages/analytics/amplify_analytics_pinpoint_dart/pubspec.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint_dart/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/an
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   amplify_core: ">=2.12.0 <2.13.0"

--- a/packages/api/amplify_api/example/pubspec.yaml
+++ b/packages/api/amplify_api/example/pubspec.yaml
@@ -6,8 +6,8 @@ description: Demonstrates how to use the amplify_api plugin.
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: ^3.10.0
-  flutter: ">=3.38.1"
+  sdk: ^3.11.0
+  flutter: ">=3.41.0"
 
 dependencies:
   amplify_api: ">=1.0.0-next.8 <1.0.0-next.9"

--- a/packages/api/amplify_api/pubspec.yaml
+++ b/packages/api/amplify_api/pubspec.yaml
@@ -6,8 +6,8 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/ap
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.10.0
-  flutter: ">=3.38.1"
+  sdk: ^3.11.0
+  flutter: ">=3.41.0"
 
 # Helps `pana` since we do not use Flutter plugins for most platforms
 platforms:

--- a/packages/api/amplify_api_dart/pubspec.yaml
+++ b/packages/api/amplify_api_dart/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/ap
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   amplify_core: ">=2.12.0 <2.13.0"

--- a/packages/auth/amplify_auth_cognito/example/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito/example/pubspec.yaml
@@ -4,8 +4,8 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
-  flutter: ">=3.38.1"
+  sdk: ^3.11.0
+  flutter: ">=3.41.0"
 
 dependencies:
   amplify_api: any

--- a/packages/auth/amplify_auth_cognito/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito/pubspec.yaml
@@ -6,8 +6,8 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/au
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.10.0
-  flutter: ">=3.38.1"
+  sdk: ^3.11.0
+  flutter: ">=3.41.0"
 
 # Helps `pana` since we do not use Flutter plugins for most platforms
 platforms:

--- a/packages/auth/amplify_auth_cognito_dart/example/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_dart/example/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   amplify_auth_cognito_dart: any

--- a/packages/auth/amplify_auth_cognito_dart/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_dart/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/next/packages/au
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   amplify_analytics_pinpoint_dart: ">=0.4.17 <0.5.0"

--- a/packages/auth/amplify_auth_cognito_test/pubspec.yaml
+++ b/packages/auth/amplify_auth_cognito_test/pubspec.yaml
@@ -3,7 +3,7 @@ description: Tests for the amplify_auth_cognito_dart package.
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   amplify_analytics_pinpoint_dart: any

--- a/packages/authenticator/amplify_authenticator/example/pubspec.yaml
+++ b/packages/authenticator/amplify_authenticator/example/pubspec.yaml
@@ -18,8 +18,8 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.10.0
-  flutter: ">=3.38.1"
+  sdk: ^3.11.0
+  flutter: ">=3.41.0"
 
 dependencies:
   amplify_auth_cognito: ">=1.0.0-next.8 <1.0.0-next.9"

--- a/packages/authenticator/amplify_authenticator/pubspec.yaml
+++ b/packages/authenticator/amplify_authenticator/pubspec.yaml
@@ -6,8 +6,8 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/au
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.10.0
-  flutter: ">=3.38.1"
+  sdk: ^3.11.0
+  flutter: ">=3.41.0"
 
 dependencies:
   amplify_auth_cognito: ">=2.12.0 <2.13.0"

--- a/packages/authenticator/amplify_authenticator_test/example/pubspec.yaml
+++ b/packages/authenticator/amplify_authenticator_test/example/pubspec.yaml
@@ -4,8 +4,8 @@ publish_to: "none"
 version: 0.1.0
 
 environment:
-  sdk: ^3.10.0
-  flutter: ">=3.38.1"
+  sdk: ^3.11.0
+  flutter: ">=3.41.0"
 
 dependencies:
   amplify_authenticator: any

--- a/packages/authenticator/amplify_authenticator_test/pubspec.yaml
+++ b/packages/authenticator/amplify_authenticator_test/pubspec.yaml
@@ -4,8 +4,8 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
-  flutter: ">=3.38.1"
+  sdk: ^3.11.0
+  flutter: ">=3.41.0"
 
 dependencies:
   amplify_authenticator: any

--- a/packages/aws_common/pubspec.yaml
+++ b/packages/aws_common/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/aw
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   async: ^2.10.0

--- a/packages/aws_signature_v4/example/pubspec.yaml
+++ b/packages/aws_signature_v4/example/pubspec.yaml
@@ -2,7 +2,7 @@ name: example
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   args: ^2.5.0

--- a/packages/aws_signature_v4/pubspec.yaml
+++ b/packages/aws_signature_v4/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/aw
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   async: ^2.10.0

--- a/packages/common/amplify_db_common/example/pubspec.yaml
+++ b/packages/common/amplify_db_common/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the amplify_db_common plugin.
 publish_to: "none"
 
 environment:
-  flutter: ">=3.38.1"
-  sdk: ^3.10.0
+  flutter: ">=3.41.0"
+  sdk: ^3.11.0
 
 dependencies:
   amplify_db_common: ">=0.4.5 <0.5.0"

--- a/packages/common/amplify_db_common/pubspec.yaml
+++ b/packages/common/amplify_db_common/pubspec.yaml
@@ -6,8 +6,8 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/co
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.10.0
-  flutter: ">=3.38.1"
+  sdk: ^3.11.0
+  flutter: ">=3.41.0"
 
 dependencies:
   amplify_db_common_dart: ">=0.4.19 <0.5.0"

--- a/packages/common/amplify_db_common_dart/example/pubspec.yaml
+++ b/packages/common/amplify_db_common_dart/example/pubspec.yaml
@@ -7,7 +7,7 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   amplify_db_common_dart: ">=0.4.0 <0.5.0"

--- a/packages/common/amplify_db_common_dart/pubspec.yaml
+++ b/packages/common/amplify_db_common_dart/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/co
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   amplify_core: ">=2.12.0 <2.13.0"

--- a/packages/example_common/example/pubspec.yaml
+++ b/packages/example_common/example/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   example_common:

--- a/packages/example_common/pubspec.yaml
+++ b/packages/example_common/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   meta: ^1.16.0

--- a/packages/kinesis/amplify_firehose/example/pubspec.yaml
+++ b/packages/kinesis/amplify_firehose/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Example app for amplify_firehose.
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
-  flutter: ">=3.38.1"
+  sdk: ^3.11.0
+  flutter: ">=3.41.0"
 
 dependencies:
   amplify_auth_cognito: any

--- a/packages/kinesis/amplify_firehose/pubspec.yaml
+++ b/packages/kinesis/amplify_firehose/pubspec.yaml
@@ -13,8 +13,8 @@ topics:
   - aws-amplify
 
 environment:
-  sdk: ^3.10.0
-  flutter: ">=3.38.1"
+  sdk: ^3.11.0
+  flutter: ">=3.41.0"
 
 platforms:
   ios:

--- a/packages/kinesis/amplify_firehose_dart/pubspec.yaml
+++ b/packages/kinesis/amplify_firehose_dart/pubspec.yaml
@@ -13,7 +13,7 @@ topics:
   - aws-amplify
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   amplify_core: ">=2.12.0 <2.13.0"

--- a/packages/kinesis/amplify_kinesis/example/pubspec.yaml
+++ b/packages/kinesis/amplify_kinesis/example/pubspec.yaml
@@ -5,8 +5,8 @@ version: 0.1.0
 publish_to: "none"
 
 environment:
-  sdk: ^3.10.0
-  flutter: ">=3.38.1"
+  sdk: ^3.11.0
+  flutter: ">=3.41.0"
 
 dependencies:
   amplify_auth_cognito: any

--- a/packages/kinesis/amplify_kinesis/pubspec.yaml
+++ b/packages/kinesis/amplify_kinesis/pubspec.yaml
@@ -13,8 +13,8 @@ topics:
   - aws-amplify
 
 environment:
-  sdk: ^3.10.0
-  flutter: ">=3.38.1"
+  sdk: ^3.11.0
+  flutter: ">=3.41.0"
 
 # Helps `pana` since we do not use Flutter plugins for most platforms
 platforms:

--- a/packages/kinesis/amplify_kinesis_dart/pubspec.yaml
+++ b/packages/kinesis/amplify_kinesis_dart/pubspec.yaml
@@ -13,7 +13,7 @@ topics:
   - aws-amplify
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   amplify_core: ">=2.12.0 <2.13.0"

--- a/packages/kinesis/amplify_record_cache_dart/pubspec.yaml
+++ b/packages/kinesis/amplify_record_cache_dart/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/ki
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   amplify_db_common_dart: ">=0.4.19 <0.5.0"

--- a/packages/notifications/push/amplify_push_notifications/example/pubspec.yaml
+++ b/packages/notifications/push/amplify_push_notifications/example/pubspec.yaml
@@ -4,8 +4,8 @@ publish_to: "none"
 version: 0.1.0
 
 environment:
-  flutter: ">=3.38.1"
-  sdk: ^3.10.0
+  flutter: ">=3.41.0"
+  sdk: ^3.11.0
 
 dependencies:
   amplify_push_notifications:

--- a/packages/notifications/push/amplify_push_notifications/pubspec.yaml
+++ b/packages/notifications/push/amplify_push_notifications/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.10.0
-  flutter: ">=3.38.1"
+  sdk: ^3.11.0
+  flutter: ">=3.41.0"
 
 dependencies:
   amplify_core: ">=2.12.0 <2.13.0"

--- a/packages/notifications/push/amplify_push_notifications_pinpoint/example/pubspec.yaml
+++ b/packages/notifications/push/amplify_push_notifications_pinpoint/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the amplify_push_notifications_pinpoint plu
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: ^3.10.0
-  flutter: ">=3.38.1"
+  sdk: ^3.11.0
+  flutter: ">=3.41.0"
 
 dependencies:
   amplify_auth_cognito: ">=1.0.0-next.8 <1.0.0-next.9"

--- a/packages/notifications/push/amplify_push_notifications_pinpoint/pubspec.yaml
+++ b/packages/notifications/push/amplify_push_notifications_pinpoint/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.10.0
-  flutter: ">=3.38.1"
+  sdk: ^3.11.0
+  flutter: ">=3.41.0"
 
 # Helps `pana` since it does not detect Android support.
 platforms:

--- a/packages/secure_storage/amplify_secure_storage/example/pubspec.yaml
+++ b/packages/secure_storage/amplify_secure_storage/example/pubspec.yaml
@@ -4,8 +4,8 @@ description: Demonstrates how to use the amplify_secure_storage plugin and house
 publish_to: "none"
 
 environment:
-  sdk: ^3.10.0
-  flutter: ">=3.38.1"
+  sdk: ^3.11.0
+  flutter: ">=3.41.0"
 
 dependencies:
   amplify_secure_storage: ">=0.3.0 <0.4.0"

--- a/packages/secure_storage/amplify_secure_storage/pubspec.yaml
+++ b/packages/secure_storage/amplify_secure_storage/pubspec.yaml
@@ -6,8 +6,8 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/se
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.10.0
-  flutter: ">=3.38.1"
+  sdk: ^3.11.0
+  flutter: ">=3.41.0"
 
 dependencies:
   amplify_secure_storage_dart: ">=0.5.11 <0.6.0"

--- a/packages/secure_storage/amplify_secure_storage_dart/example/pubspec.yaml
+++ b/packages/secure_storage/amplify_secure_storage_dart/example/pubspec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   amplify_secure_storage_dart: ">=0.5.3 <0.6.0"

--- a/packages/secure_storage/amplify_secure_storage_dart/pubspec.yaml
+++ b/packages/secure_storage/amplify_secure_storage_dart/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/se
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 # Explicitly declare platform support to help `pana`
 platforms:

--- a/packages/secure_storage/amplify_secure_storage_test/pubspec.yaml
+++ b/packages/secure_storage/amplify_secure_storage_test/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   amplify_secure_storage_dart: any

--- a/packages/smithy/goldens/lib/awsJson1_0/pubspec.yaml
+++ b/packages/smithy/goldens/lib/awsJson1_0/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   smithy:

--- a/packages/smithy/goldens/lib/awsJson1_1/pubspec.yaml
+++ b/packages/smithy/goldens/lib/awsJson1_1/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   smithy:

--- a/packages/smithy/goldens/lib/awsQuery/pubspec.yaml
+++ b/packages/smithy/goldens/lib/awsQuery/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   smithy:

--- a/packages/smithy/goldens/lib/ec2Query/pubspec.yaml
+++ b/packages/smithy/goldens/lib/ec2Query/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   smithy:

--- a/packages/smithy/goldens/lib/restJson1/pubspec.yaml
+++ b/packages/smithy/goldens/lib/restJson1/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   smithy:

--- a/packages/smithy/goldens/lib/restXml/pubspec.yaml
+++ b/packages/smithy/goldens/lib/restXml/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   smithy:

--- a/packages/smithy/goldens/lib/restXmlWithNamespace/pubspec.yaml
+++ b/packages/smithy/goldens/lib/restXmlWithNamespace/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   smithy:

--- a/packages/smithy/goldens/lib2/awsJson1_0/pubspec.yaml
+++ b/packages/smithy/goldens/lib2/awsJson1_0/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   smithy:

--- a/packages/smithy/goldens/lib2/awsJson1_1/pubspec.yaml
+++ b/packages/smithy/goldens/lib2/awsJson1_1/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   smithy:

--- a/packages/smithy/goldens/lib2/awsQuery/pubspec.yaml
+++ b/packages/smithy/goldens/lib2/awsQuery/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   smithy:

--- a/packages/smithy/goldens/lib2/custom/pubspec.yaml
+++ b/packages/smithy/goldens/lib2/custom/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   smithy:

--- a/packages/smithy/goldens/lib2/ec2Query/pubspec.yaml
+++ b/packages/smithy/goldens/lib2/ec2Query/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   smithy:

--- a/packages/smithy/goldens/lib2/restJson1/pubspec.yaml
+++ b/packages/smithy/goldens/lib2/restJson1/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   smithy:

--- a/packages/smithy/goldens/lib2/restXml/pubspec.yaml
+++ b/packages/smithy/goldens/lib2/restXml/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   smithy:

--- a/packages/smithy/goldens/lib2/restXmlWithNamespace/pubspec.yaml
+++ b/packages/smithy/goldens/lib2/restXmlWithNamespace/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   smithy:

--- a/packages/smithy/goldens/pubspec.yaml
+++ b/packages/smithy/goldens/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   aws_common: ^0.5.0+2

--- a/packages/smithy/smithy/pubspec.yaml
+++ b/packages/smithy/smithy/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/sm
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   async: ^2.10.0

--- a/packages/smithy/smithy_aws/pubspec.yaml
+++ b/packages/smithy/smithy_aws/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/sm
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   aws_common: ">=0.7.14 <0.8.0"

--- a/packages/smithy/smithy_codegen/pubspec.yaml
+++ b/packages/smithy/smithy_codegen/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/sm
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   args: ^2.5.0

--- a/packages/smithy/smithy_test/pubspec.yaml
+++ b/packages/smithy/smithy_test/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/sm
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   async: ^2.10.0

--- a/packages/storage/amplify_storage_s3/example/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3/example/pubspec.yaml
@@ -4,8 +4,8 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
-  flutter: ">=3.38.1"
+  sdk: ^3.11.0
+  flutter: ">=3.41.0"
 
 dependencies:
   amplify_auth_cognito: any

--- a/packages/storage/amplify_storage_s3/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3/pubspec.yaml
@@ -6,8 +6,8 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/st
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.10.0
-  flutter: ">=3.38.1"
+  sdk: ^3.11.0
+  flutter: ">=3.41.0"
 
 # Helps `pana` since we do not use Flutter plugins for most platforms
 platforms:

--- a/packages/storage/amplify_storage_s3_dart/example/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3_dart/example/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   amplify_auth_cognito_dart: any

--- a/packages/storage/amplify_storage_s3_dart/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3_dart/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/st
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   amplify_core: ">=2.12.0 <2.13.0"

--- a/packages/test/amplify_auth_integration_test/pubspec.yaml
+++ b/packages/test/amplify_auth_integration_test/pubspec.yaml
@@ -6,8 +6,8 @@ issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
-  flutter: ">=3.38.1"
+  sdk: ^3.11.0
+  flutter: ">=3.41.0"
 
 dependencies:
   amplify_api: any

--- a/packages/test/amplify_integration_test/pubspec.yaml
+++ b/packages/test/amplify_integration_test/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/aws-amplify/amplify-flutter
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   amplify_auth_cognito_dart: any

--- a/packages/test/amplify_test/pubspec.yaml
+++ b/packages/test/amplify_test/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/aws-amplify/amplify-flutter
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   amplify_core: any

--- a/packages/test/pub_server/pubspec.yaml
+++ b/packages/test/pub_server/pubspec.yaml
@@ -6,7 +6,7 @@ issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   archive: ^4.0.0

--- a/packages/worker_bee/e2e/pubspec.yaml
+++ b/packages/worker_bee/e2e/pubspec.yaml
@@ -3,7 +3,7 @@ description: E2E tests for the worker_bee package.
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   aws_common: ">=0.4.0 <0.5.0"

--- a/packages/worker_bee/e2e_flutter_test/pubspec.yaml
+++ b/packages/worker_bee/e2e_flutter_test/pubspec.yaml
@@ -4,8 +4,8 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  flutter: ">=3.38.1"
-  sdk: ^3.10.0
+  flutter: ">=3.41.0"
+  sdk: ^3.11.0
 
 dependencies:
   e2e:

--- a/packages/worker_bee/e2e_test/pubspec.yaml
+++ b/packages/worker_bee/e2e_test/pubspec.yaml
@@ -3,7 +3,7 @@ description: E2E tests for the worker_bee package.
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   web: ^1.1.1

--- a/packages/worker_bee/worker_bee/example/pubspec.yaml
+++ b/packages/worker_bee/worker_bee/example/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/packages/worker_bee/worker_bee/pubspec.yaml
+++ b/packages/worker_bee/worker_bee/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/wo
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   async: ^2.10.0

--- a/packages/worker_bee/worker_bee_builder/pubspec.yaml
+++ b/packages/worker_bee/worker_bee_builder/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/wo
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   analyzer: ^9.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,8 +3,8 @@ publish_to: none
 
 # The current constraints for Dart and Flutter SDKs.
 environment:
-  sdk: ^3.10.0
-  flutter: ">=3.38.1"
+  sdk: ^3.11.0
+  flutter: ">=3.41.0"
 
 # Global dependency versions for third-party dependencies of
 # Amplify Flutter projects. These represent the values which

--- a/templates/dart-package/hooks/pubspec.yaml
+++ b/templates/dart-package/hooks/pubspec.yaml
@@ -2,7 +2,7 @@ name: dart_package_hooks
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   mason: ^0.1.1

--- a/templates/flutter-package/hooks/pubspec.yaml
+++ b/templates/flutter-package/hooks/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_package_hooks
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   mason: ^0.1.1


### PR DESCRIPTION
We need to bump our SDK version because of this issue: https://github.com/simolus3/drift/issues/3827 
Our workflows indicate that we can't support Dart 3.10 anymore (or need to pin some dependencies down).  
At the same time, this stabilizes Windows workflows, we had many TCP timeouts. I stack these two (rebase with merge) so that the Windows changes get triggered for testing.