### PR TITLE
fix(worker_bee): Point `fallbackUrls` at real filenames after `copy_builder` use

### DIFF
--- a/packages/auth/amplify_auth_cognito_dart/lib/src/asf/asf_worker.worker.js.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/asf/asf_worker.worker.js.dart
@@ -31,15 +31,25 @@ class ASFWorkerImpl extends ASFWorker {
         .takeWhile((segment) => segment != 'test')
         .map(Uri.encodeComponent)
         .join('/');
-    const relativePath = zDebugMode
-        ? 'packages/amplify_auth_cognito_dart/src/workers/workers.debug.dart.js'
-        : 'packages/amplify_auth_cognito_dart/src/workers/workers.release.dart.js';
-    final testRelativePath = Uri(
-      scheme: baseUri.scheme,
-      host: baseUri.host,
-      port: baseUri.port,
-      path: '$basePath/test/$relativePath',
-    ).toString();
-    return [relativePath, testRelativePath];
+    const relativePaths = zDebugMode
+        ? [
+            'packages/amplify_auth_cognito_dart/src/workers/workers.js',
+            'packages/amplify_auth_cognito_dart/src/workers/workers.debug.dart.js',
+          ]
+        : [
+            'packages/amplify_auth_cognito_dart/src/workers/workers.min.js',
+            'packages/amplify_auth_cognito_dart/src/workers/workers.release.dart.js',
+          ];
+    return [
+      for (final relativePath in relativePaths) ...[
+        relativePath,
+        Uri(
+          scheme: baseUri.scheme,
+          host: baseUri.host,
+          port: baseUri.port,
+          path: '$basePath/test/$relativePath',
+        ).toString(),
+      ],
+    ];
   }
 }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/flows/device/confirm_device_worker.worker.js.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/flows/device/confirm_device_worker.worker.js.dart
@@ -31,15 +31,25 @@ class ConfirmDeviceWorkerImpl extends ConfirmDeviceWorker {
         .takeWhile((segment) => segment != 'test')
         .map(Uri.encodeComponent)
         .join('/');
-    const relativePath = zDebugMode
-        ? 'packages/amplify_auth_cognito_dart/src/workers/workers.debug.dart.js'
-        : 'packages/amplify_auth_cognito_dart/src/workers/workers.release.dart.js';
-    final testRelativePath = Uri(
-      scheme: baseUri.scheme,
-      host: baseUri.host,
-      port: baseUri.port,
-      path: '$basePath/test/$relativePath',
-    ).toString();
-    return [relativePath, testRelativePath];
+    const relativePaths = zDebugMode
+        ? [
+            'packages/amplify_auth_cognito_dart/src/workers/workers.js',
+            'packages/amplify_auth_cognito_dart/src/workers/workers.debug.dart.js',
+          ]
+        : [
+            'packages/amplify_auth_cognito_dart/src/workers/workers.min.js',
+            'packages/amplify_auth_cognito_dart/src/workers/workers.release.dart.js',
+          ];
+    return [
+      for (final relativePath in relativePaths) ...[
+        relativePath,
+        Uri(
+          scheme: baseUri.scheme,
+          host: baseUri.host,
+          port: baseUri.port,
+          path: '$basePath/test/$relativePath',
+        ).toString(),
+      ],
+    ];
   }
 }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/flows/srp/srp_device_password_verifier_worker.worker.js.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/flows/srp/srp_device_password_verifier_worker.worker.js.dart
@@ -32,15 +32,25 @@ class SrpDevicePasswordVerifierWorkerImpl
         .takeWhile((segment) => segment != 'test')
         .map(Uri.encodeComponent)
         .join('/');
-    const relativePath = zDebugMode
-        ? 'packages/amplify_auth_cognito_dart/src/workers/workers.debug.dart.js'
-        : 'packages/amplify_auth_cognito_dart/src/workers/workers.release.dart.js';
-    final testRelativePath = Uri(
-      scheme: baseUri.scheme,
-      host: baseUri.host,
-      port: baseUri.port,
-      path: '$basePath/test/$relativePath',
-    ).toString();
-    return [relativePath, testRelativePath];
+    const relativePaths = zDebugMode
+        ? [
+            'packages/amplify_auth_cognito_dart/src/workers/workers.js',
+            'packages/amplify_auth_cognito_dart/src/workers/workers.debug.dart.js',
+          ]
+        : [
+            'packages/amplify_auth_cognito_dart/src/workers/workers.min.js',
+            'packages/amplify_auth_cognito_dart/src/workers/workers.release.dart.js',
+          ];
+    return [
+      for (final relativePath in relativePaths) ...[
+        relativePath,
+        Uri(
+          scheme: baseUri.scheme,
+          host: baseUri.host,
+          port: baseUri.port,
+          path: '$basePath/test/$relativePath',
+        ).toString(),
+      ],
+    ];
   }
 }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/flows/srp/srp_init_worker.worker.js.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/flows/srp/srp_init_worker.worker.js.dart
@@ -31,15 +31,25 @@ class SrpInitWorkerImpl extends SrpInitWorker {
         .takeWhile((segment) => segment != 'test')
         .map(Uri.encodeComponent)
         .join('/');
-    const relativePath = zDebugMode
-        ? 'packages/amplify_auth_cognito_dart/src/workers/workers.debug.dart.js'
-        : 'packages/amplify_auth_cognito_dart/src/workers/workers.release.dart.js';
-    final testRelativePath = Uri(
-      scheme: baseUri.scheme,
-      host: baseUri.host,
-      port: baseUri.port,
-      path: '$basePath/test/$relativePath',
-    ).toString();
-    return [relativePath, testRelativePath];
+    const relativePaths = zDebugMode
+        ? [
+            'packages/amplify_auth_cognito_dart/src/workers/workers.js',
+            'packages/amplify_auth_cognito_dart/src/workers/workers.debug.dart.js',
+          ]
+        : [
+            'packages/amplify_auth_cognito_dart/src/workers/workers.min.js',
+            'packages/amplify_auth_cognito_dart/src/workers/workers.release.dart.js',
+          ];
+    return [
+      for (final relativePath in relativePaths) ...[
+        relativePath,
+        Uri(
+          scheme: baseUri.scheme,
+          host: baseUri.host,
+          port: baseUri.port,
+          path: '$basePath/test/$relativePath',
+        ).toString(),
+      ],
+    ];
   }
 }

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/flows/srp/srp_password_verifier_worker.worker.js.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/flows/srp/srp_password_verifier_worker.worker.js.dart
@@ -31,15 +31,25 @@ class SrpPasswordVerifierWorkerImpl extends SrpPasswordVerifierWorker {
         .takeWhile((segment) => segment != 'test')
         .map(Uri.encodeComponent)
         .join('/');
-    const relativePath = zDebugMode
-        ? 'packages/amplify_auth_cognito_dart/src/workers/workers.debug.dart.js'
-        : 'packages/amplify_auth_cognito_dart/src/workers/workers.release.dart.js';
-    final testRelativePath = Uri(
-      scheme: baseUri.scheme,
-      host: baseUri.host,
-      port: baseUri.port,
-      path: '$basePath/test/$relativePath',
-    ).toString();
-    return [relativePath, testRelativePath];
+    const relativePaths = zDebugMode
+        ? [
+            'packages/amplify_auth_cognito_dart/src/workers/workers.js',
+            'packages/amplify_auth_cognito_dart/src/workers/workers.debug.dart.js',
+          ]
+        : [
+            'packages/amplify_auth_cognito_dart/src/workers/workers.min.js',
+            'packages/amplify_auth_cognito_dart/src/workers/workers.release.dart.js',
+          ];
+    return [
+      for (final relativePath in relativePaths) ...[
+        relativePath,
+        Uri(
+          scheme: baseUri.scheme,
+          host: baseUri.host,
+          port: baseUri.port,
+          path: '$basePath/test/$relativePath',
+        ).toString(),
+      ],
+    ];
   }
 }

--- a/packages/secure_storage/amplify_secure_storage_dart/lib/src/worker/secure_storage_worker.worker.js.dart
+++ b/packages/secure_storage/amplify_secure_storage_dart/lib/src/worker/secure_storage_worker.worker.js.dart
@@ -31,15 +31,25 @@ class SecureStorageWorkerImpl extends SecureStorageWorker {
         .takeWhile((segment) => segment != 'test')
         .map(Uri.encodeComponent)
         .join('/');
-    const relativePath = zDebugMode
-        ? 'packages/amplify_secure_storage_dart/src/worker/workers.debug.dart.js'
-        : 'packages/amplify_secure_storage_dart/src/worker/workers.release.dart.js';
-    final testRelativePath = Uri(
-      scheme: baseUri.scheme,
-      host: baseUri.host,
-      port: baseUri.port,
-      path: '$basePath/test/$relativePath',
-    ).toString();
-    return [relativePath, testRelativePath];
+    const relativePaths = zDebugMode
+        ? [
+            'packages/amplify_secure_storage_dart/src/worker/workers.js',
+            'packages/amplify_secure_storage_dart/src/worker/workers.debug.dart.js',
+          ]
+        : [
+            'packages/amplify_secure_storage_dart/src/worker/workers.min.js',
+            'packages/amplify_secure_storage_dart/src/worker/workers.release.dart.js',
+          ];
+    return [
+      for (final relativePath in relativePaths) ...[
+        relativePath,
+        Uri(
+          scheme: baseUri.scheme,
+          host: baseUri.host,
+          port: baseUri.port,
+          path: '$basePath/test/$relativePath',
+        ).toString(),
+      ],
+    ];
   }
 }

--- a/packages/worker_bee/e2e/lib/e2e_worker.worker.js.dart
+++ b/packages/worker_bee/e2e/lib/e2e_worker.worker.js.dart
@@ -17,15 +17,25 @@ class E2EWorkerImpl extends E2EWorker {
         .takeWhile((segment) => segment != 'test')
         .map(Uri.encodeComponent)
         .join('/');
-    const relativePath = zDebugMode
-        ? 'packages/e2e/workers.debug.dart.js'
-        : 'packages/e2e/workers.release.dart.js';
-    final testRelativePath = Uri(
-      scheme: baseUri.scheme,
-      host: baseUri.host,
-      port: baseUri.port,
-      path: '$basePath/test/$relativePath',
-    ).toString();
-    return [relativePath, testRelativePath];
+    const relativePaths = zDebugMode
+        ? [
+            'packages/e2e/workers.js',
+            'packages/e2e/workers.debug.dart.js',
+          ]
+        : [
+            'packages/e2e/workers.min.js',
+            'packages/e2e/workers.release.dart.js',
+          ];
+    return [
+      for (final relativePath in relativePaths) ...[
+        relativePath,
+        Uri(
+          scheme: baseUri.scheme,
+          host: baseUri.host,
+          port: baseUri.port,
+          path: '$basePath/test/$relativePath',
+        ).toString(),
+      ],
+    ];
   }
 }

--- a/packages/worker_bee/e2e/lib/e2e_worker_no_result.worker.js.dart
+++ b/packages/worker_bee/e2e/lib/e2e_worker_no_result.worker.js.dart
@@ -31,15 +31,25 @@ class E2EWorkerNoResultImpl extends E2EWorkerNoResult {
         .takeWhile((segment) => segment != 'test')
         .map(Uri.encodeComponent)
         .join('/');
-    const relativePath = zDebugMode
-        ? 'packages/e2e/workers.debug.dart.js'
-        : 'packages/e2e/workers.release.dart.js';
-    final testRelativePath = Uri(
-      scheme: baseUri.scheme,
-      host: baseUri.host,
-      port: baseUri.port,
-      path: '$basePath/test/$relativePath',
-    ).toString();
-    return [relativePath, testRelativePath];
+    const relativePaths = zDebugMode
+        ? [
+            'packages/e2e/workers.js',
+            'packages/e2e/workers.debug.dart.js',
+          ]
+        : [
+            'packages/e2e/workers.min.js',
+            'packages/e2e/workers.release.dart.js',
+          ];
+    return [
+      for (final relativePath in relativePaths) ...[
+        relativePath,
+        Uri(
+          scheme: baseUri.scheme,
+          host: baseUri.host,
+          port: baseUri.port,
+          path: '$basePath/test/$relativePath',
+        ).toString(),
+      ],
+    ];
   }
 }

--- a/packages/worker_bee/e2e/lib/e2e_worker_null_result.worker.js.dart
+++ b/packages/worker_bee/e2e/lib/e2e_worker_null_result.worker.js.dart
@@ -31,15 +31,25 @@ class E2EWorkerNullResultImpl extends E2EWorkerNullResult {
         .takeWhile((segment) => segment != 'test')
         .map(Uri.encodeComponent)
         .join('/');
-    const relativePath = zDebugMode
-        ? 'packages/e2e/workers.debug.dart.js'
-        : 'packages/e2e/workers.release.dart.js';
-    final testRelativePath = Uri(
-      scheme: baseUri.scheme,
-      host: baseUri.host,
-      port: baseUri.port,
-      path: '$basePath/test/$relativePath',
-    ).toString();
-    return [relativePath, testRelativePath];
+    const relativePaths = zDebugMode
+        ? [
+            'packages/e2e/workers.js',
+            'packages/e2e/workers.debug.dart.js',
+          ]
+        : [
+            'packages/e2e/workers.min.js',
+            'packages/e2e/workers.release.dart.js',
+          ];
+    return [
+      for (final relativePath in relativePaths) ...[
+        relativePath,
+        Uri(
+          scheme: baseUri.scheme,
+          host: baseUri.host,
+          port: baseUri.port,
+          path: '$basePath/test/$relativePath',
+        ).toString(),
+      ],
+    ];
   }
 }

--- a/packages/worker_bee/e2e/lib/e2e_worker_throws.worker.js.dart
+++ b/packages/worker_bee/e2e/lib/e2e_worker_throws.worker.js.dart
@@ -31,15 +31,25 @@ class E2EWorkerThrowsImpl extends E2EWorkerThrows {
         .takeWhile((segment) => segment != 'test')
         .map(Uri.encodeComponent)
         .join('/');
-    const relativePath = zDebugMode
-        ? 'packages/e2e/workers.debug.dart.js'
-        : 'packages/e2e/workers.release.dart.js';
-    final testRelativePath = Uri(
-      scheme: baseUri.scheme,
-      host: baseUri.host,
-      port: baseUri.port,
-      path: '$basePath/test/$relativePath',
-    ).toString();
-    return [relativePath, testRelativePath];
+    const relativePaths = zDebugMode
+        ? [
+            'packages/e2e/workers.js',
+            'packages/e2e/workers.debug.dart.js',
+          ]
+        : [
+            'packages/e2e/workers.min.js',
+            'packages/e2e/workers.release.dart.js',
+          ];
+    return [
+      for (final relativePath in relativePaths) ...[
+        relativePath,
+        Uri(
+          scheme: baseUri.scheme,
+          host: baseUri.host,
+          port: baseUri.port,
+          path: '$basePath/test/$relativePath',
+        ).toString(),
+      ],
+    ];
   }
 }

--- a/packages/worker_bee/e2e/lib/e2e_worker_void_result.worker.js.dart
+++ b/packages/worker_bee/e2e/lib/e2e_worker_void_result.worker.js.dart
@@ -31,15 +31,25 @@ class E2EWorkerVoidResultImpl extends E2EWorkerVoidResult {
         .takeWhile((segment) => segment != 'test')
         .map(Uri.encodeComponent)
         .join('/');
-    const relativePath = zDebugMode
-        ? 'packages/e2e/workers.debug.dart.js'
-        : 'packages/e2e/workers.release.dart.js';
-    final testRelativePath = Uri(
-      scheme: baseUri.scheme,
-      host: baseUri.host,
-      port: baseUri.port,
-      path: '$basePath/test/$relativePath',
-    ).toString();
-    return [relativePath, testRelativePath];
+    const relativePaths = zDebugMode
+        ? [
+            'packages/e2e/workers.js',
+            'packages/e2e/workers.debug.dart.js',
+          ]
+        : [
+            'packages/e2e/workers.min.js',
+            'packages/e2e/workers.release.dart.js',
+          ];
+    return [
+      for (final relativePath in relativePaths) ...[
+        relativePath,
+        Uri(
+          scheme: baseUri.scheme,
+          host: baseUri.host,
+          port: baseUri.port,
+          path: '$basePath/test/$relativePath',
+        ).toString(),
+      ],
+    ];
   }
 }

--- a/packages/worker_bee/worker_bee/example/lib/workers/echo_worker.worker.js.dart
+++ b/packages/worker_bee/worker_bee/example/lib/workers/echo_worker.worker.js.dart
@@ -17,15 +17,25 @@ class EchoWorkerImpl extends EchoWorker {
         .takeWhile((segment) => segment != 'test')
         .map(Uri.encodeComponent)
         .join('/');
-    const relativePath = zDebugMode
-        ? 'packages/worker_bee_example/workers.debug.dart.js'
-        : 'packages/worker_bee_example/workers.release.dart.js';
-    final testRelativePath = Uri(
-      scheme: baseUri.scheme,
-      host: baseUri.host,
-      port: baseUri.port,
-      path: '$basePath/test/$relativePath',
-    ).toString();
-    return [relativePath, testRelativePath];
+    const relativePaths = zDebugMode
+        ? [
+            'packages/worker_bee_example/workers.js',
+            'packages/worker_bee_example/workers.debug.dart.js',
+          ]
+        : [
+            'packages/worker_bee_example/workers.min.js',
+            'packages/worker_bee_example/workers.release.dart.js',
+          ];
+    return [
+      for (final relativePath in relativePaths) ...[
+        relativePath,
+        Uri(
+          scheme: baseUri.scheme,
+          host: baseUri.host,
+          port: baseUri.port,
+          path: '$basePath/test/$relativePath',
+        ).toString(),
+      ],
+    ];
   }
 }

--- a/packages/worker_bee/worker_bee_builder/lib/src/impl/js.dart
+++ b/packages/worker_bee/worker_bee_builder/lib/src/impl/js.dart
@@ -78,35 +78,35 @@ return ${allocate(DartTypes.awsCommon.zDebugMode)} ? '$_workersJsPath' : '$_mini
   }
 
   Code get _fallbackUrls {
-    return Block.of([
-      const Code('''
-    // When running in a test, we need to find the `packages` directory which
-    // is symlinked in the root `test/` directory.
-    final baseUri = Uri.base;
-    final basePath = baseUri.pathSegments
-        .takeWhile((segment) => segment != 'test')
-        .map(Uri.encodeComponent)
-        .join('/');'''),
-      declareConst('relativePath')
-          .assign(
-            DartTypes.awsCommon.zDebugMode.conditional(
-              literalString(_debugWorkersJsPath),
-              literalString(_releaseWorkersJsPath),
-            ),
-          )
-          .statement,
-      const Code(r'''
-    final testRelativePath = Uri(
+    // Offer both the copy-builder output names (`workers.js` / `workers.min.js`)
+    // and the raw build_web_compilers names (`*.debug.dart.js` /
+    // `*.release.dart.js`), each also under the `test/` symlink used by tests.
+    return Code.scope(
+      (allocate) =>
+          '''
+// When running in a test, we need to find the `packages` directory which
+// is symlinked in the root `test/` directory.
+final baseUri = Uri.base;
+final basePath = baseUri.pathSegments
+    .takeWhile((segment) => segment != 'test')
+    .map(Uri.encodeComponent)
+    .join('/');
+const relativePaths = ${allocate(DartTypes.awsCommon.zDebugMode)}
+    ? ['$_workersJsPath', '$_debugWorkersJsPath']
+    : ['$_minifiedWorkersJsPath', '$_releaseWorkersJsPath'];
+return [
+  for (final relativePath in relativePaths) ...[
+    relativePath,
+    Uri(
       scheme: baseUri.scheme,
       host: baseUri.host,
       port: baseUri.port,
-      path: '$basePath/test/$relativePath',
-    ).toString();'''),
-      literalList([
-        refer('relativePath'),
-        refer('testRelativePath'),
-      ]).returned.statement,
-    ]);
+      path: '\$basePath/test/\$relativePath',
+    ).toString(),
+  ],
+];
+''',
+    );
   }
 
   Class get _workerClass => Class(


### PR DESCRIPTION
We use worker_bee in combination with copy_builder that renames `*.debug.*` and `*.release.*` files. Because of this, the fallback paths are broken. We add the new names while keeping the old one in the list of fallback urls since one of them will probably work. This is done because of https://github.com/aws-amplify/amplify-flutter/pull/7094#issuecomment-4956407174. 