### PR TITLE
fix(aft): Cascade constraints for `foundation_dart` +`foundation_dart_bridge` minor bumps

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -127,6 +127,12 @@ aft:
       packages:
         - worker_bee
         - worker_bee_builder
+    - name: Foundation Dart
+      packages:
+        - amplify_foundation_dart
+    - name: Foundation Dart Bridge
+      packages:
+        - amplify_foundation_dart_bridge
 
   # Scripts which are runnable via `aft run <script-name>`.
   scripts:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -133,6 +133,9 @@ aft:
     - name: Foundation Dart Bridge
       packages:
         - amplify_foundation_dart_bridge
+    - name: Record Cache Dart
+      packages:
+        - amplify_record_cache_dart
 
   # Scripts which are runnable via `aft run <script-name>`.
   scripts:


### PR DESCRIPTION
`amplify_foundation_dart` and `amplify_foundation_dart_bridge` are post-1.0 but in no aft component, so a minor bump doesn't widen dependents' `<nextMinor` constraints (the 1b4e201b7 failure fixed by hand in #7080).

Add solo, default-minor-propagating components so the constraint cascade happens automatically.