### PR TITLE
fix(aft): cascade constraint widening on out-of-range bumps

### DIFF
--- a/packages/aft/lib/src/repo.dart
+++ b/packages/aft/lib/src/repo.dart
@@ -14,6 +14,7 @@ import 'package:collection/collection.dart';
 import 'package:git/git.dart';
 import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
+import 'package:pubspec_parse/pubspec_parse.dart';
 
 /// Encapsulates all repository functionality including package and Git
 /// management.
@@ -342,29 +343,32 @@ class Repo {
             pkg.pubspecInfo.pubspec.dependencies.keys.contains(package.name) ||
             pkg.pubspecInfo.pubspec.devDependencies.keys.contains(package.name),
       );
-      if (commit.isBreakingChange || propagateToComponent) {
-        // Back-propagate to all dependent packages for breaking changes or
-        // changes that need to propagate to a component.
-        //
-        // Since we set semantic version constraints, only a breaking change in
-        // a direct dependency or a change that requires propagation
-        // necessitates a version bump.
-        logger.verbose(
-          'Breaking change. Performing dfs on dependent packages...',
-        );
-        for (final dependent in packageDependents) {
-          logger.verbose('found dependent package ${dependent.name}');
-          if (dependent.isPublishable && canBump(dependent)) {
-            bumpVersion(
-              dependent,
-              commit: commit,
-              type: VersionBumpType.patch,
-              canBump: canBump,
-              includeInChangelog: false,
-            );
-          }
-          updateConstraint(package, dependent);
+      // Widen a dependent's constraint (and patch-bump it) when the change is
+      // breaking or propagates to a component, OR when `newVersion` falls
+      // outside the dependent's existing constraint on `package`. The latter
+      // catches minor/major bumps that cross a dependent's `<nextMinor` cap
+      // even for component-less packages, so dependents aren't stranded. Patch
+      // bumps that stay in range don't trigger it.
+      final backPropagate = commit.isBreakingChange || propagateToComponent;
+      for (final dependent in packageDependents) {
+        final existingConstraint = dependent.hostedConstraintOn(package.name);
+        final outOfRange =
+            existingConstraint != null &&
+            !existingConstraint.allows(newVersion);
+        if (!backPropagate && !outOfRange) {
+          continue;
         }
+        logger.verbose('found dependent package ${dependent.name}');
+        if (dependent.isPublishable && canBump(dependent)) {
+          bumpVersion(
+            dependent,
+            commit: commit,
+            type: VersionBumpType.patch,
+            canBump: canBump,
+            includeInChangelog: false,
+          );
+        }
+        updateConstraint(package, dependent);
       }
 
       // Propagate to all component packages.
@@ -436,6 +440,20 @@ class Repo {
         package.name,
       ], newConstraint);
     }
+  }
+}
+
+extension on PackageInfo {
+  /// The hosted version constraint this package declares on [dependencyName],
+  /// or `null` if it is absent or not a hosted (versioned) dependency.
+  VersionConstraint? hostedConstraintOn(String dependencyName) {
+    final dependency =
+        pubspecInfo.pubspec.dependencies[dependencyName] ??
+        pubspecInfo.pubspec.devDependencies[dependencyName];
+    return switch (dependency) {
+      HostedDependency(:final version) => version,
+      _ => null,
+    };
   }
 }
 

--- a/packages/aft/test/version_bump/cascade_constraint_test.dart
+++ b/packages/aft/test/version_bump/cascade_constraint_test.dart
@@ -1,0 +1,97 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:aft/aft.dart';
+import 'package:aft/src/changelog/commit_message.dart';
+import 'package:aft/src/repo.dart';
+import 'package:pub_semver/pub_semver.dart';
+import 'package:pubspec_parse/pubspec_parse.dart';
+import 'package:test/test.dart';
+
+import '../helpers/descriptors.dart' as d;
+
+const _leaf = 'amplify_foundation_test';
+const _dependent = 'amplify_consumer_test';
+
+VersionConstraint _constraintOn(PackageInfo package, String dependency) {
+  final pubspec = Pubspec.parse(
+    package.pubspecInfo.pubspecYamlEditor.toString(),
+  );
+  final dep = pubspec.dependencies[dependency];
+  return (dep as HostedDependency).version;
+}
+
+void main() {
+  group('bumpVersion constraint cascade', () {
+    late Repo repo;
+    late PackageInfo leaf;
+    late PackageInfo dependent;
+
+    setUp(() async {
+      repo = await d.repo([
+        // Component-less, post-1.0 package (not in any component).
+        d.package(_leaf, version: '1.2.3'),
+        // First-party dependent pinning the leaf with a tight upper bound.
+        d.package(
+          _dependent,
+          version: '1.0.0',
+          dependencies: {_leaf: '>=1.2.0 <1.3.0'},
+        ),
+      ]).create();
+      leaf = repo[_leaf];
+      dependent = repo[_dependent];
+      // Precondition: the leaf really is component-less.
+      final component = repo.aftConfig.componentForPackage(_leaf);
+      expect(repo.components.containsKey(component), isFalse);
+    });
+
+    test('minor bump out of range widens + patch-bumps the dependent', () {
+      repo.bumpVersion(
+        leaf,
+        commit: CommitMessage.parse('0' * 40, 'feat: test', body: ''),
+        type: VersionBumpType.nonBreaking,
+        canBump: (_) => true,
+        includeInChangelog: false,
+      );
+
+      expect(
+        repo.versionChanges.proposedVersion(_leaf),
+        Version(1, 3, 0),
+        reason: 'post-1.0 feat is a minor bump',
+      );
+      expect(
+        repo.versionChanges.proposedVersion(_dependent),
+        Version(1, 0, 1),
+        reason:
+            'dependent is patch-bumped even though the leaf has no component',
+      );
+      expect(
+        _constraintOn(dependent, _leaf),
+        VersionConstraint.parse('>=1.3.0 <1.4.0'),
+        reason: 'stranded constraint is widened to include the new version',
+      );
+    });
+
+    test('patch bump in range leaves the dependent untouched', () {
+      repo.bumpVersion(
+        leaf,
+        commit: CommitMessage.parse('0' * 40, 'fix: test', body: ''),
+        type: VersionBumpType.patch,
+        canBump: (_) => true,
+        includeInChangelog: false,
+      );
+
+      expect(repo.versionChanges.proposedVersion(_leaf), Version(1, 2, 4));
+      expect(
+        repo.versionChanges.proposedVersion(_dependent),
+        isNull,
+        reason: 'in-range patch bump must not cascade',
+      );
+      expect(
+        _constraintOn(dependent, _leaf),
+        VersionConstraint.parse('>=1.2.0 <1.3.0'),
+        reason: 'constraint already allows the new version',
+      );
+    });
+  });
+}


### PR DESCRIPTION
version-bump only widened dependents' constraints on breaking/component changes, so a component-less post-1.0 package's minor bump stranded dependents at `<nextMinor` (the 1b4e201b7 failure, config-patched in #7125).

Now widen (and patch-bump) a dependent whenever a bump falls outside its existing constraint, regardless of component. Makes the per-package solo components from #7125 unnecessary going forward.

Adds a focused bumpVersion regression test; existing version_bump snapshots unchanged.