### PR TITLE
fix(foundation): Autogenerate `version.dart`

### DIFF
--- a/packages/amplify_foundation/amplify_foundation_dart/analysis_options.yaml
+++ b/packages/amplify_foundation/amplify_foundation_dart/analysis_options.yaml
@@ -3,3 +3,4 @@ include: package:amplify_lints/library.yaml
 analyzer:
   exclude:
     - '**/*.g.dart'
+    - 'lib/src/version.dart'

--- a/packages/amplify_foundation/amplify_foundation_dart/lib/src/version.dart
+++ b/packages/amplify_foundation/amplify_foundation_dart/lib/src/version.dart
@@ -1,5 +1,2 @@
-// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
-
-/// The current package version.
-const packageVersion = '2.10.0';
+// Generated code. Do not modify.
+const packageVersion = '2.12.0';

--- a/packages/amplify_foundation/amplify_foundation_dart/pubspec.yaml
+++ b/packages/amplify_foundation/amplify_foundation_dart/pubspec.yaml
@@ -15,6 +15,7 @@ dev_dependencies:
   amplify_lints: ">=3.1.5 <3.2.0"
   build_runner: ^2.4.15
   build_test: ^3.1.1
+  build_version: ^2.1.1
   build_web_compilers: ^4.1.4
   json_serializable: ^6.11.0
   test: ^1.22.1


### PR DESCRIPTION
`packageVersion` in `amplify_foundation_dart` was stuck at `2.10.0` (used in kinesis/firehose user agents).

- Add `build_version` so `aft` version bumps regenerate `version.dart`
- Regenerate: `2.10.0` → `2.12.0`

## Verification
- `dart analyze`: no issues
- `dart test -p vm`: all pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.