### PR TITLE
chore(storage): Clean up unneeded dev dependency

### DIFF
--- a/packages/storage/amplify_storage_s3_dart/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3_dart/pubspec.yaml
@@ -28,9 +28,7 @@ dependencies:
 dev_dependencies:
   amplify_lints: ">=3.1.6 <3.2.0"
   build_runner: ^2.4.15
-  build_test: ^3.1.1
   build_verify: ^3.0.0
-  build_web_compilers: ^4.1.4
   built_value_generator: ^8.10.1
   drift_dev: ^2.34.0
   json_serializable: ^6.11.0

--- a/packages/storage/amplify_storage_s3_dart/pubspec.yaml
+++ b/packages/storage/amplify_storage_s3_dart/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
 dev_dependencies:
   amplify_lints: ">=3.1.6 <3.2.0"
   build_runner: ^2.4.15
+  build_test: ^3.1.1
   build_verify: ^3.0.0
   built_value_generator: ^8.10.1
   drift_dev: ^2.34.0


### PR DESCRIPTION
A dependency introduced by https://github.com/aws-amplify/amplify-flutter/pull/7148 isn't needed.