### PR TITLE
fix(storage): Don't fail resumed multipart upload on stale part cancellation

### DIFF
--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_upload_task.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_upload_task.dart
@@ -25,6 +25,25 @@ import 'package:smithy_aws/smithy_aws.dart' as smithy_aws;
 // https://www.iana.org/assignments/media-types/application/octet-stream
 const fallbackContentType = 'application/octet-stream';
 
+/// Simple lock for serializing async operations.
+class _Lock {
+  Future<dynamic>? _last;
+
+  Future<T> synchronized<T>(FutureOr<T> Function() func) async {
+    final prev = _last;
+    final completer = Completer<void>.sync();
+    _last = completer.future;
+    try {
+      if (prev != null) await prev;
+      final result = func();
+      return result is Future ? await result : result;
+    } finally {
+      if (identical(_last, completer.future)) _last = null;
+      completer.complete();
+    }
+  }
+}
+
 /// {@template amplify_storage_s3_dart.upload_task}
 /// A task created to fulfill an upload operation.
 ///
@@ -179,6 +198,7 @@ class S3UploadTask {
   int _currentSubTaskId = 0;
   final Completer<void> _determineUploadModeCompleter = Completer();
   Completer<void>? _uploadPartBatchingCompleter;
+  final _stateLock = _Lock();
 
   FutureOr<void> get _uploadModeDetermined =>
       _determineUploadModeCompleter.future;
@@ -262,25 +282,18 @@ class S3UploadTask {
   /// but it doesn't cancel any ongoing parts upload (as AWSHttpOperation is
   /// currently not returned from S3Client APIs).
   Future<void> pause() async {
-    // can pause when upload is actually started
     await _uploadModeDetermined;
-    if (!_isMultipartUpload || _state != StorageTransferState.inProgress) {
-      return;
-    }
-    _state = StorageTransferState.paused;
-
-    await _uploadPartBatchingCompleted;
-
-    _subtasksStreamSubscription.pause();
-
-    // pause() (via onPause) cancels the in-flight parts but doesn't await their
-    // handlers. Drain them here so their CancellationExceptions are handled
-    // while _state is still `paused`. Otherwise a delayed cancellation can land
-    // after resume() flips _state back to inProgress (e.g. dart2wasm) and be
-    // mistaken for a real failure.
-    await Future.wait(
-      _ongoingSubtasks.values.map((subtask) => subtask.request).toList(),
-    );
+    return _stateLock.synchronized(() async {
+      if (!_isMultipartUpload || _state != StorageTransferState.inProgress) {
+        return;
+      }
+      _state = StorageTransferState.paused;
+      await _uploadPartBatchingCompleted;
+      _subtasksStreamSubscription.pause();
+      await Future.wait(
+        _ongoingSubtasks.values.map((subtask) => subtask.request).toList(),
+      );
+    });
   }
 
   /// Resumes the [S3UploadTask] that is in a [StorageTransferState.paused] state.
@@ -288,15 +301,15 @@ class S3UploadTask {
   /// For single putObject, resume doesn't take any effect.
   /// For multipart upload, resume reschedules remaining subtasks.
   Future<void> resume() async {
-    // can resume when the upload is multipart upload and paused
     await _uploadModeDetermined;
-    if (!_isMultipartUpload || _state != StorageTransferState.paused) {
-      return;
-    }
-    _state = StorageTransferState.inProgress;
-    await _uploadPartBatchingCompleted;
-
-    _subtasksStreamSubscription.resume();
+    return _stateLock.synchronized(() async {
+      if (!_isMultipartUpload || _state != StorageTransferState.paused) {
+        return;
+      }
+      _state = StorageTransferState.inProgress;
+      await _uploadPartBatchingCompleted;
+      _subtasksStreamSubscription.resume();
+    });
   }
 
   /// Cancels the [S3UploadTask].

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_upload_task.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_upload_task.dart
@@ -290,9 +290,6 @@ class S3UploadTask {
       _state = StorageTransferState.paused;
       await _uploadPartBatchingCompleted;
       _subtasksStreamSubscription.pause();
-      await Future.wait(
-        _ongoingSubtasks.values.map((subtask) => subtask.request).toList(),
-      );
     });
   }
 

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_upload_task.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_upload_task.dart
@@ -282,16 +282,22 @@ class S3UploadTask {
   /// but it doesn't cancel any ongoing parts upload (as AWSHttpOperation is
   /// currently not returned from S3Client APIs).
   Future<void> pause() async {
-    // can pause when upload is actually started
     await _uploadModeDetermined;
-    return _stateLock.synchronized(() async {
+    final shouldDrain = await _stateLock.synchronized(() async {
       if (!_isMultipartUpload || _state != StorageTransferState.inProgress) {
-        return;
+        return false;
       }
       _state = StorageTransferState.paused;
       await _uploadPartBatchingCompleted;
       _subtasksStreamSubscription.pause();
+      return true;
     });
+    // Drain outside the lock to avoid holding it during potentially long waits
+    if (shouldDrain) {
+      await Future.wait(
+        _ongoingSubtasks.values.map((subtask) => subtask.request).toList(),
+      );
+    }
   }
 
   /// Resumes the [S3UploadTask] that is in a [StorageTransferState.paused] state.
@@ -299,7 +305,6 @@ class S3UploadTask {
   /// For single putObject, resume doesn't take any effect.
   /// For multipart upload, resume reschedules remaining subtasks.
   Future<void> resume() async {
-    // can resume when the upload is multipart upload and paused
     await _uploadModeDetermined;
     return _stateLock.synchronized(() async {
       if (!_isMultipartUpload || _state != StorageTransferState.paused) {

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_upload_task.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_upload_task.dart
@@ -282,6 +282,7 @@ class S3UploadTask {
   /// but it doesn't cancel any ongoing parts upload (as AWSHttpOperation is
   /// currently not returned from S3Client APIs).
   Future<void> pause() async {
+    // can pause when upload is actually started
     await _uploadModeDetermined;
     return _stateLock.synchronized(() async {
       if (!_isMultipartUpload || _state != StorageTransferState.inProgress) {
@@ -298,6 +299,7 @@ class S3UploadTask {
   /// For single putObject, resume doesn't take any effect.
   /// For multipart upload, resume reschedules remaining subtasks.
   Future<void> resume() async {
+    // can resume when the upload is multipart upload and paused
     await _uploadModeDetermined;
     return _stateLock.synchronized(() async {
       if (!_isMultipartUpload || _state != StorageTransferState.paused) {

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_upload_task.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_upload_task.dart
@@ -272,6 +272,15 @@ class S3UploadTask {
     await _uploadPartBatchingCompleted;
 
     _subtasksStreamSubscription.pause();
+
+    // pause() (via onPause) cancels the in-flight parts but doesn't await their
+    // handlers. Drain them here so their CancellationExceptions are handled
+    // while _state is still `paused`. Otherwise a delayed cancellation can land
+    // after resume() flips _state back to inProgress (e.g. dart2wasm) and be
+    // mistaken for a real failure.
+    await Future.wait(
+      _ongoingSubtasks.values.map((subtask) => subtask.request).toList(),
+    );
   }
 
   /// Resumes the [S3UploadTask] that is in a [StorageTransferState.paused] state.

--- a/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/task/s3_upload_task_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/task/s3_upload_task_test.dart
@@ -2085,6 +2085,77 @@ void main() {
             verify(uploadPartSmithyOperation3.cancel).called(1);
           },
         );
+
+        // Regression for a race that surfaces reliably on dart2wasm: pause()
+        // cancels in-flight parts but used not to wait for them to settle, so
+        // the CancellationException could land after resume() flipped state
+        // back to inProgress and be mistaken for a real failure (failing the
+        // upload with "Bad state: Future already completed"). pause() must not
+        // return until the parts it cancels have settled.
+        test(
+          'pause() waits for in-flight parts to settle before returning',
+          () async {
+            final uploadTask = S3UploadTask.fromAWSFile(
+              testLocalFile,
+              s3Client: s3Client,
+              s3ClientConfig: defaultS3ClientConfig,
+              pathResolver: pathResolver,
+              bucket: testBucket,
+              awsRegion: testRegion,
+              path: const StoragePath.fromString(testKey),
+              options: testUploadDataOptions,
+              logger: logger,
+              transferDatabase: transferDatabase,
+            );
+
+            // Gate the in-flight parts so their CancellationException is only
+            // delivered when we release it.
+            final releaseCancel = Completer<void>();
+            Future<Never> gatedCancel(Invocation _) async {
+              await releaseCancel.future;
+              throw const CancellationException();
+            }
+
+            when(
+              () => uploadPartSmithyOperation1.result,
+            ).thenAnswer(gatedCancel);
+            when(
+              () => uploadPartSmithyOperation2.result,
+            ).thenAnswer(gatedCancel);
+            when(
+              () => uploadPartSmithyOperation3.result,
+            ).thenAnswer(gatedCancel);
+
+            unawaited(uploadTask.start());
+
+            var paused = false;
+            final pauseFuture = uploadTask.pause().then((_) => paused = true);
+
+            // pause() is blocked draining the in-flight parts until we release
+            // their cancellation.
+            await pumpEventQueue();
+            expect(paused, isFalse);
+
+            releaseCancel.complete();
+            await pauseFuture;
+            expect(paused, isTrue);
+
+            // Resumed upload succeeds.
+            when(
+              () => uploadPartSmithyOperation1.result,
+            ).thenAnswer((_) async => testUploadPartOutput1);
+            when(
+              () => uploadPartSmithyOperation2.result,
+            ).thenAnswer((_) async => testUploadPartOutput2);
+            when(
+              () => uploadPartSmithyOperation3.result,
+            ).thenAnswer((_) async => testUploadPartOutput3);
+
+            await uploadTask.resume();
+            final result = await uploadTask.result;
+            expect(result.path, TestPathResolver.path);
+          },
+        );
       });
     });
 


### PR DESCRIPTION
Fixes the wasm CI failure from #7148.

`pause()` cancels in-flight upload parts (via `onPause`) but didn't await their handlers. So a part's `CancellationException` could be delivered after `resume()` flipped state back to `inProgress` (dart2wasm scheduling), get treated as a real failure, and double-complete the upload (`Bad state: Future already completed`).

Fix: drain the cancelled parts in `pause()` so they settle while state is still `paused`. The existing `_state` guard then handles them correctly — no change to the error path.

Verified: unit (VM + dart2wasm), regression test fails without the fix on both. Full suite green.