### PR TITLE
chore(smithy): bump xml dependency to 7.x

### DIFF
--- a/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/xml_attributes_input_output.dart
+++ b/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/xml_attributes_input_output.dart
@@ -124,7 +124,7 @@ class XmlAttributesInputOutputRestXmlSerializer
     if (attr != null) {
       result$.add(
         _i3.XmlAttribute(
-          _i3.XmlName('test'),
+          _i3.XmlName.parts('test'),
           (serializers.serialize(attr, specifiedType: const FullType(String))
               as String),
         ),

--- a/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/xml_attributes_on_payload_input_output.dart
+++ b/packages/smithy/goldens/lib/restXml/lib/src/rest_xml_protocol/model/xml_attributes_on_payload_input_output.dart
@@ -139,7 +139,7 @@ class XmlAttributesOnPayloadInputOutputRestXmlSerializer
     if (attr != null) {
       result$.add(
         _i3.XmlAttribute(
-          _i3.XmlName('test'),
+          _i3.XmlName.parts('test'),
           (serializers.serialize(attr, specifiedType: const FullType(String))
               as String),
         ),

--- a/packages/smithy/goldens/lib/restXml/pubspec.yaml
+++ b/packages/smithy/goldens/lib/restXml/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   fixnum: ^1.0.0
   built_collection: ^5.1.1
   meta: ^1.16.0
-  xml: ^6.5.0
+  xml: ^7.0.0
   shelf_router: ^1.1.3
   shelf: ^1.4.0
   aws_signature_v4:

--- a/packages/smithy/goldens/lib/restXmlWithNamespace/lib/src/rest_xml_protocol_namespace/model/nested_with_namespace.dart
+++ b/packages/smithy/goldens/lib/restXmlWithNamespace/lib/src/rest_xml_protocol_namespace/model/nested_with_namespace.dart
@@ -100,7 +100,7 @@ class NestedWithNamespaceRestXmlSerializer
     if (attrField != null) {
       result$.add(
         _i3.XmlAttribute(
-          _i3.XmlName('xsi:someName'),
+          _i3.XmlName.parts('xsi:someName'),
           (serializers.serialize(
                 attrField,
                 specifiedType: const FullType(String),

--- a/packages/smithy/goldens/lib/restXmlWithNamespace/pubspec.yaml
+++ b/packages/smithy/goldens/lib/restXmlWithNamespace/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   aws_common:
     path: ../../../../aws_common
   built_value: ^8.10.1
-  xml: ^6.5.0
+  xml: ^7.0.0
   fixnum: ^1.0.0
   meta: ^1.16.0
   built_collection: ^5.1.1

--- a/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/xml_attributes_input_output.dart
+++ b/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/xml_attributes_input_output.dart
@@ -124,7 +124,7 @@ class XmlAttributesInputOutputRestXmlSerializer
     if (attr != null) {
       result$.add(
         _i3.XmlAttribute(
-          _i3.XmlName('test'),
+          _i3.XmlName.parts('test'),
           (serializers.serialize(attr, specifiedType: const FullType(String))
               as String),
         ),

--- a/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/xml_attributes_on_payload_input_output.dart
+++ b/packages/smithy/goldens/lib2/restXml/lib/src/rest_xml_protocol/model/xml_attributes_on_payload_input_output.dart
@@ -139,7 +139,7 @@ class XmlAttributesOnPayloadInputOutputRestXmlSerializer
     if (attr != null) {
       result$.add(
         _i3.XmlAttribute(
-          _i3.XmlName('test'),
+          _i3.XmlName.parts('test'),
           (serializers.serialize(attr, specifiedType: const FullType(String))
               as String),
         ),

--- a/packages/smithy/goldens/lib2/restXml/pubspec.yaml
+++ b/packages/smithy/goldens/lib2/restXml/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   fixnum: ^1.0.0
   built_collection: ^5.1.1
   meta: ^1.16.0
-  xml: ^6.5.0
+  xml: ^7.0.0
   shelf_router: ^1.1.3
   shelf: ^1.4.0
   aws_signature_v4:

--- a/packages/smithy/goldens/lib2/restXmlWithNamespace/lib/src/rest_xml_protocol_namespace/model/nested_with_namespace.dart
+++ b/packages/smithy/goldens/lib2/restXmlWithNamespace/lib/src/rest_xml_protocol_namespace/model/nested_with_namespace.dart
@@ -100,7 +100,7 @@ class NestedWithNamespaceRestXmlSerializer
     if (attrField != null) {
       result$.add(
         _i3.XmlAttribute(
-          _i3.XmlName('xsi:someName'),
+          _i3.XmlName.parts('xsi:someName'),
           (serializers.serialize(
                 attrField,
                 specifiedType: const FullType(String),

--- a/packages/smithy/goldens/lib2/restXmlWithNamespace/pubspec.yaml
+++ b/packages/smithy/goldens/lib2/restXmlWithNamespace/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   aws_common:
     path: ../../../../aws_common
   built_value: ^8.10.1
-  xml: ^6.5.0
+  xml: ^7.0.0
   fixnum: ^1.0.0
   meta: ^1.16.0
   built_collection: ^5.1.1

--- a/packages/smithy/smithy/lib/src/serialization/xml/smithy_xml_plugin.dart
+++ b/packages/smithy/smithy/lib/src/serialization/xml/smithy_xml_plugin.dart
@@ -4,7 +4,7 @@
 import 'package:built_value/serializer.dart';
 import 'package:collection/collection.dart';
 import 'package:smithy/smithy.dart';
-import 'package:xml/xml.dart';
+import 'package:xml/xml.dart' hide XmlNamespace;
 
 class SmithyXmlPlugin implements SerializerPlugin {
   const SmithyXmlPlugin();
@@ -40,7 +40,7 @@ class SmithyXmlPlugin implements SerializerPlugin {
       wireName.name,
       nest: () {
         if (namespace != null) {
-          builder.namespace(namespace.uri, namespace.prefix);
+          builder.namespaceUri(namespace.prefix, namespace.uri);
         }
         while (iterator.moveNext()) {
           final key = iterator.current;
@@ -81,10 +81,10 @@ class SmithyXmlPlugin implements SerializerPlugin {
             XmlAttribute(key.namespace!.xmlName, key.namespace!.uri),
           );
         }
-        key = XmlName(key.name);
+        key = XmlName.parts(key.name);
       } else {
         if (key is! XmlName) {
-          key = XmlName(key as String);
+          key = XmlName.parts(key as String);
         }
       }
       key as XmlName;
@@ -129,15 +129,15 @@ class SmithyXmlPlugin implements SerializerPlugin {
       elementName = key.name;
       namespace = key.namespace;
     }
-    final namespaces = <String, String>{
-      if (namespace != null) namespace.uri: namespace.prefix ?? '',
+    final namespaceUris = <String?, String?>{
+      if (namespace != null) namespace.prefix: namespace.uri,
     };
 
     if (value is Iterable<XmlNode> || value is! Iterable<Object?>) {
       if (value is XmlElement) {
         builder.element(
           elementName,
-          namespaces: namespaces,
+          namespaceUris: namespaceUris,
           attributes: _toAttributeMap([...attributes, ...value.attributes]),
           nest: value.children,
         );
@@ -145,7 +145,7 @@ class SmithyXmlPlugin implements SerializerPlugin {
         builder.element(
           elementName,
           attributes: _toAttributeMap(attributes),
-          namespaces: namespaces,
+          namespaceUris: namespaceUris,
           nest: value,
         );
       }
@@ -155,7 +155,7 @@ class SmithyXmlPlugin implements SerializerPlugin {
     builder.element(
       elementName,
       attributes: _toAttributeMap(attributes),
-      namespaces: namespaces,
+      namespaceUris: namespaceUris,
       nest: () {
         final values = value.toList();
         for (var i = 0; i < values.length; i++) {

--- a/packages/smithy/smithy/lib/src/serialization/xml/xml_built_list_serializer.dart
+++ b/packages/smithy/smithy/lib/src/serialization/xml/xml_built_list_serializer.dart
@@ -5,7 +5,7 @@ import 'package:built_collection/built_collection.dart';
 import 'package:built_value/serializer.dart';
 import 'package:collection/collection.dart';
 import 'package:smithy/smithy.dart';
-import 'package:xml/xml.dart';
+import 'package:xml/xml.dart' hide XmlNamespace;
 
 class XmlBuiltListSerializer
     implements StructuredSerializer<BuiltList<Object?>> {

--- a/packages/smithy/smithy/lib/src/serialization/xml/xml_built_set_serializer.dart
+++ b/packages/smithy/smithy/lib/src/serialization/xml/xml_built_set_serializer.dart
@@ -5,7 +5,7 @@ import 'package:built_collection/built_collection.dart';
 import 'package:built_value/serializer.dart';
 import 'package:collection/collection.dart';
 import 'package:smithy/smithy.dart';
-import 'package:xml/xml.dart';
+import 'package:xml/xml.dart' hide XmlNamespace;
 
 class XmlBuiltSetSerializer implements StructuredSerializer<BuiltSet<Object?>> {
   const XmlBuiltSetSerializer({

--- a/packages/smithy/smithy/lib/src/serialization/xml/xml_namespace.dart
+++ b/packages/smithy/smithy/lib/src/serialization/xml/xml_namespace.dart
@@ -10,8 +10,9 @@ class XmlNamespace with AWSEquatable<XmlNamespace> {
   final String uri;
   final String? prefix;
 
-  XmlName get xmlName =>
-      prefix == null ? XmlName('xmlns') : XmlName(prefix!, 'xmlns');
+  XmlName get xmlName => prefix == null
+      ? const XmlName.parts('xmlns')
+      : XmlName.parts(prefix!, prefix: 'xmlns');
 
   @override
   List<Object?> get props => [uri, prefix];

--- a/packages/smithy/smithy/pubspec.yaml
+++ b/packages/smithy/smithy/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   retry: ^3.1.2
   shelf: ^1.4.0
   typed_data: ^1.3.0
-  xml: ^6.5.0
+  xml: ^7.0.0
 
 dev_dependencies:
   amplify_lints: ">=3.1.6 <3.2.0"

--- a/packages/smithy/smithy_aws/pubspec.yaml
+++ b/packages/smithy/smithy_aws/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   meta: ^1.16.0
   path: ^1.8.0
   smithy: ">=0.7.12 <0.8.0"
-  xml: ^6.5.0
+  xml: ^7.0.0
 
 dev_dependencies:
   amplify_lints: ">=3.1.6 <3.2.0"

--- a/packages/smithy/smithy_codegen/lib/src/generator/serialization/structure_xml_serializer_generator.dart
+++ b/packages/smithy/smithy_codegen/lib/src/generator/serialization/structure_xml_serializer_generator.dart
@@ -238,7 +238,7 @@ class StructureXmlSerializerGenerator extends StructureSerializerGenerator {
             .property('add')
             .call([
               DartTypes.xml.xmlAttribute.newInstance([
-                DartTypes.xml.xmlName.newInstance([
+                DartTypes.xml.xmlName.newInstanceNamed('parts', [
                   literalString(serializeMemberWireName(member)),
                 ]),
                 serializerFor(member, memberRef).asA(DartTypes.core.string),

--- a/packages/smithy/smithy_codegen/pubspec.yaml
+++ b/packages/smithy/smithy_codegen/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
   smithy: ">=0.7.1 <0.8.0"
   smithy_aws: ">=0.7.0 <0.8.0"
   tuple: ^2.0.0
-  xml: ^6.5.0
+  xml: ^7.0.0
   yaml_edit: ^2.1.0
 
 dev_dependencies:

--- a/packages/smithy/smithy_test/lib/src/xml/equatable.dart
+++ b/packages/smithy/smithy_test/lib/src/xml/equatable.dart
@@ -87,9 +87,9 @@ class _EquatableVisitor with XmlVisitor {
   /// Visit an [XmlText] node.
   @override
   void visitText(XmlText node) {
-    final text = node.text.trim();
+    final text = node.value.trim();
     if (text.isNotEmpty) {
-      props.add(node.text);
+      props.add(node.value);
     }
   }
 }

--- a/packages/smithy/smithy_test/pubspec.yaml
+++ b/packages/smithy/smithy_test/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   smithy: any
   test: ^1.22.1
   tuple: ^2.0.0
-  xml: ^6.5.0
+  xml: ^7.0.0
 
 dev_dependencies:
   amplify_lints:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,7 +44,7 @@ dependencies:
   stack_trace: ^1.10.0
   uuid: ^4.5.1
   win32: ^6.0.1
-  xml: ^6.5.0
+  xml: ^7.0.0
   test: ^1.22.1
 
 aft:


### PR DESCRIPTION
Fixes #7146

## What this does

Bumps the Dart `xml` dependency from `6.5.0` to `7.0.0` across the smithy packages and goldens. The constraint is `^7.0.0` and it currently resolves to `7.0.1`.

The pinned `^6.5.0` constraint meant consumers who wanted `xml` 7.x could not resolve it, and a dependency override was not a viable workaround. This unpins us onto the 7.x line.

## Breaking changes in xml 7.x that required code changes

1. **New public `XmlNamespace` node type.** `package:xml` now exports its own `XmlNamespace`, which collides with smithy's own `XmlNamespace` class and caused an ambiguous import. The affected serialization files now hide the xml one on import so smithy's continues to be used.
2. **`XmlName` unnamed constructor deprecated.** Replaced with `XmlName.parts(local, {prefix})`, which produces an identical name for the values we pass.
3. **`XmlBuilder.namespace(uri, prefix)` deprecated.** Replaced with `namespaceUri(prefix, uri)`. The argument order is reversed in the new API.
4. **`element(namespaces: {uri: prefix})` deprecated.** Replaced with `element(namespaceUris: {prefix: uri})`. The map is now keyed by prefix instead of uri, so the key/value orientation is flipped. A missing prefix has to be passed as `null` rather than an empty string, otherwise the default namespace serializes as a malformed `xmlns:` declaration.

## Files touched

**Constraints (`xml: ^7.0.0`), 9 pubspecs:** repo root `pubspec.yaml`, `smithy`, `smithy_aws`, `smithy_test`, `smithy_codegen`, and the four goldens packages (`lib/restXml`, `lib/restXmlWithNamespace`, `lib2/restXml`, `lib2/restXmlWithNamespace`).

**Source migration (`smithy`):**
- `smithy_xml_plugin.dart`: hide `XmlNamespace` on the xml import, migrate `namespace()` to `namespaceUri()`, migrate the `namespaces:` map to `namespaceUris:` at three call sites, and use `XmlName.parts`.
- `xml_built_list_serializer.dart` and `xml_built_set_serializer.dart`: hide `XmlNamespace` on the xml import, which also clears the follow-on type errors on `memberNamespace`.
- `xml_namespace.dart`: use `XmlName.parts`.

**Other source:**
- `smithy_test/lib/src/xml/equatable.dart`: `XmlNode.text` to `XmlNode.value`.

**Generator + regenerated goldens:**
- `smithy_codegen` `structure_xml_serializer_generator.dart` now emits `XmlName.parts(...)` for XML attribute names.
- The six regenerated goldens under `restXml` and `restXmlWithNamespace` reflect the `XmlName.parts` output.

## Verification

- `dart analyze` is clean on `smithy`, `smithy_aws`, `smithy_codegen`, and `goldens`. `smithy_test` only shows pre-existing `implementation_imports` infos unrelated to this change.
- Test suites run and passing:
  - `smithy`: 45 passed
  - `smithy_aws`: 9 passed
  - `smithy_codegen`: 46 passed (33 skipped), excluding the `ensure_build` note below
  - goldens `restXml` (both `lib` and `lib2`): 167 passed, 3 skipped each
  - goldens `restXmlWithNamespace` (both): 2 passed each
  - goldens `awsQuery` (both): 72 passed, 4 skipped each
  - goldens `ec2Query` (both): 54 passed, 3 skipped each
  - goldens `restJson1` (regression check on a non-XML protocol): 207 passed, 10 skipped
- The golden tests caught a real bug in the first pass of the namespace migration: passing an empty-string prefix produced a malformed `xmlns:` declaration. This was fixed by passing the nullable prefix directly so a missing prefix maps to the default namespace, and `XmlNamespaces` now passes.
- `smithy_codegen`'s `ensure_build` test passes in CI once the branch is committed. It only failed locally because `build_verify` requires a clean working tree as a precondition and the changes were still uncommitted at the time. A manual `build_runner build` produced no `.g.dart` diffs, so the generated code is in sync.
