### PR TITLE
feat(notifications): Fail fast when push is used on an unsupported platform

### DIFF
--- a/packages/notifications/push/amplify_push_notifications/lib/src/amplify_push_notifications_impl.dart
+++ b/packages/notifications/push/amplify_push_notifications/lib/src/amplify_push_notifications_impl.dart
@@ -208,10 +208,8 @@ abstract class AmplifyPushNotifications
     AmplifyOutputs? config,
     required AmplifyAuthProviderRepository authProviderRepo,
   }) async {
-    // Push notifications are backed by native iOS/Android code only; there is
-    // no web, macOS, Windows or Linux implementation. Fail fast with a clear
-    // message instead of the cryptic MissingPluginException that the native
-    // channel calls below would otherwise throw on unsupported platforms.
+    // Push notifications are backed by native iOS/Android code only.
+    // Fail fast with a clear message.
     if (!os.isIOS && !os.isAndroid) {
       throw const PushNotificationException(
         'Push notifications are only supported on iOS and Android.',

--- a/packages/notifications/push/amplify_push_notifications/lib/src/amplify_push_notifications_impl.dart
+++ b/packages/notifications/push/amplify_push_notifications/lib/src/amplify_push_notifications_impl.dart
@@ -208,6 +208,19 @@ abstract class AmplifyPushNotifications
     AmplifyOutputs? config,
     required AmplifyAuthProviderRepository authProviderRepo,
   }) async {
+    // Push notifications are backed by native iOS/Android code only; there is
+    // no web, macOS, Windows or Linux implementation. Fail fast with a clear
+    // message instead of the cryptic MissingPluginException that the native
+    // channel calls below would otherwise throw on unsupported platforms.
+    if (!os.isIOS && !os.isAndroid) {
+      throw const PushNotificationException(
+        'Push notifications are only supported on iOS and Android.',
+        recoverySuggestion:
+            'Only add the push notifications plugin on iOS and Android, e.g. '
+            'guard `Amplify.addPlugin` with a platform check.',
+      );
+    }
+
     final notificationsConfig = config?.notifications;
     if (notificationsConfig == null) {
       throw const PushNotificationException(

--- a/packages/notifications/push/amplify_push_notifications/pubspec.yaml
+++ b/packages/notifications/push/amplify_push_notifications/pubspec.yaml
@@ -8,8 +8,6 @@ environment:
   sdk: ^3.11.0
   flutter: ">=3.41.0"
 
-# Push notifications are iOS/Android only. Declaring platforms explicitly stops
-# pana from inferring (and reporting) unsupported platforms like web/desktop.
 platforms:
   ios:
   android:

--- a/packages/notifications/push/amplify_push_notifications/pubspec.yaml
+++ b/packages/notifications/push/amplify_push_notifications/pubspec.yaml
@@ -8,6 +8,12 @@ environment:
   sdk: ^3.11.0
   flutter: ">=3.41.0"
 
+# Push notifications are iOS/Android only. Declaring platforms explicitly stops
+# pana from inferring (and reporting) unsupported platforms like web/desktop.
+platforms:
+  ios:
+  android:
+
 dependencies:
   amplify_core: ">=2.13.0 <2.14.0"
   amplify_secure_storage: ">=0.5.19 <0.6.0"

--- a/packages/notifications/push/amplify_push_notifications/test/amplify_push_notifications_impl_test.dart
+++ b/packages/notifications/push/amplify_push_notifications/test/amplify_push_notifications_impl_test.dart
@@ -24,6 +24,14 @@ import 'util.dart';
 void testGlobalCallbackFunction(PushNotificationMessage pushMessage) {}
 Future<void> testBackgroundProcessor() async {}
 
+/// Runs [body] as if on iOS. `configure()` now guards on the OS being
+/// iOS/Android, so tests that would otherwise run as the host OS (macOS/Linux
+/// on CI) must declare a supported platform. iOS is used because it skips the
+/// Android-only background-processor registration these tests don't set up —
+/// matching the previous behaviour when they ran on the macOS host.
+Future<T> onMobilePlatform<T>(Future<T> Function() body) =>
+    overrideOperatingSystem(OperatingSystem('ios', ''), body);
+
 @GenerateMocks([
   PushNotificationsHostApi,
   ServiceProviderClient,
@@ -93,9 +101,11 @@ void main() {
         mockPushNotificationsHostApi.getLaunchNotification(),
       ).thenAnswer((_) async => standardAndroidPushMessage.cast());
 
-      await plugin.configure(
-        authProviderRepo: authProviderRepo,
-        config: config,
+      await onMobilePlatform(
+        () => plugin.configure(
+          authProviderRepo: authProviderRepo,
+          config: config,
+        ),
       );
 
       verify(mockPushNotificationsHostApi.requestInitialToken()).called(1);
@@ -114,9 +124,11 @@ void main() {
           mockPushNotificationsHostApi.getLaunchNotification(),
         ).thenAnswer((_) async => standardAndroidPushMessage.cast());
 
-        await plugin.configure(
-          authProviderRepo: authProviderRepo,
-          config: config,
+        await onMobilePlatform(
+          () => plugin.configure(
+            authProviderRepo: authProviderRepo,
+            config: config,
+          ),
         );
 
         verify(mockPushNotificationsHostApi.requestInitialToken()).called(1);
@@ -161,9 +173,11 @@ void main() {
         backgroundProcessor: testBackgroundProcessor,
         dependencyManager: dependencyManager,
       );
-      await plugin.configure(
-        authProviderRepo: authProviderRepo,
-        config: config,
+      await onMobilePlatform(
+        () => plugin.configure(
+          authProviderRepo: authProviderRepo,
+          config: config,
+        ),
       );
 
       await testWidgetsFlutterBinding.defaultBinaryMessenger
@@ -199,6 +213,30 @@ void main() {
       ).called(1);
     });
   });
+  group('unsupported platforms', () {
+    // Push has no implementation beyond iOS/Android; configure() must fail fast
+    // with a clear message instead of a cryptic MissingPluginException.
+    for (final osId in ['macos', 'windows', 'linux', 'fuchsia']) {
+      test('configure() throws on $osId', () async {
+        await overrideOperatingSystem(OperatingSystem(osId, ''), () async {
+          await expectLater(
+            plugin.configure(
+              authProviderRepo: authProviderRepo,
+              config: config,
+            ),
+            throwsA(
+              isA<PushNotificationException>().having(
+                (e) => e.message,
+                'message',
+                contains('only supported on iOS and Android'),
+              ),
+            ),
+          );
+        });
+      });
+    }
+  });
+
   group('Config failure cases', () {
     test(
       'should throw exception when configuring if there is no appId present',
@@ -206,16 +244,18 @@ void main() {
         final config = AmplifyOutputs.fromJson(
           jsonDecode(amplifyConfigNoPushNotification) as Map<String, Object?>,
         );
-        expect(
-          () async => plugin.configure(
-            authProviderRepo: authProviderRepo,
-            config: config,
-          ),
-          throwsA(
-            isA<PushNotificationException>().having(
-              (e) => e.message,
-              'No config',
-              contains('No Pinpoint plugin'),
+        await onMobilePlatform(
+          () async => expect(
+            () async => plugin.configure(
+              authProviderRepo: authProviderRepo,
+              config: config,
+            ),
+            throwsA(
+              isA<PushNotificationException>().having(
+                (e) => e.message,
+                'No config',
+                contains('No Pinpoint plugin'),
+              ),
             ),
           ),
         );
@@ -277,9 +317,11 @@ void main() {
         AmplifyLogger.category(
           Category.pushNotifications,
         ).registerPlugin(loggerPlugin);
-        await plugin.configure(
-          authProviderRepo: authProviderRepo,
-          config: config,
+        await onMobilePlatform(
+          () => plugin.configure(
+            authProviderRepo: authProviderRepo,
+            config: config,
+          ),
         );
         expect(loggerPlugin.logs.length, 1);
         expect(loggerPlugin.logs.first.level, LogLevel.error);
@@ -309,16 +351,18 @@ void main() {
               (_) {},
             );
       });
-      expect(
-        () async => plugin.configure(
-          authProviderRepo: authProviderRepo,
-          config: config,
-        ),
-        throwsA(
-          isA<PushNotificationException>().having(
-            (e) => e.message,
-            'token message',
-            contains('device token'),
+      await onMobilePlatform(
+        () async => expect(
+          () async => plugin.configure(
+            authProviderRepo: authProviderRepo,
+            config: config,
+          ),
+          throwsA(
+            isA<PushNotificationException>().having(
+              (e) => e.message,
+              'token message',
+              contains('device token'),
+            ),
           ),
         ),
       );
@@ -346,9 +390,11 @@ void main() {
               (_) {},
             );
       });
-      await plugin.configure(
-        authProviderRepo: authProviderRepo,
-        config: config,
+      await onMobilePlatform(
+        () => plugin.configure(
+          authProviderRepo: authProviderRepo,
+          config: config,
+        ),
       );
     });
     test('getPermissionStatus returns a permission status', () async {
@@ -444,9 +490,11 @@ void main() {
               (_) {},
             );
       });
-      await plugin.configure(
-        authProviderRepo: authProviderRepo,
-        config: config,
+      await onMobilePlatform(
+        () => plugin.configure(
+          authProviderRepo: authProviderRepo,
+          config: config,
+        ),
       );
     });
     test('identifyUser', () {
@@ -546,7 +594,10 @@ void main() {
       mockPushNotificationsHostApi.getLaunchNotification(),
     ).thenAnswer((_) async => standardAndroidPushMessage.cast());
 
-    await plugin.configure(authProviderRepo: authProviderRepo, config: config);
+    await onMobilePlatform(
+      () =>
+          plugin.configure(authProviderRepo: authProviderRepo, config: config),
+    );
 
     expect(
       plugin.launchNotification?.title,

--- a/packages/notifications/push/amplify_push_notifications/test/web_unsupported_test.dart
+++ b/packages/notifications/push/amplify_push_notifications/test/web_unsupported_test.dart
@@ -1,0 +1,63 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Push notifications have no web implementation. `configure()` must fail fast
+// on web with a clear `PushNotificationException` instead of the cryptic
+// `MissingPluginException` the native channel calls would otherwise throw.
+//
+// `zIsWeb` is a compile-time constant, so this can only be exercised on a web
+// target. Run with: flutter test test/web_unsupported_test.dart --platform chrome
+@TestOn('browser')
+library;
+
+import 'package:amplify_core/amplify_core.dart';
+// ignore: implementation_imports
+import 'package:amplify_core/src/config/amplify_outputs/notifications/notifications_outputs.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'test_data/test_amplify_push_notifications_impl.dart';
+
+class _NoopServiceProviderClient implements ServiceProviderClient {
+  @override
+  Future<void> init({
+    required NotificationsOutputs config,
+    required AmplifyAuthProviderRepository authProviderRepo,
+  }) async {}
+
+  @override
+  Future<void> registerDevice(String deviceToken) async {}
+
+  @override
+  Future<void> recordNotificationEvent({
+    required PinpointEventType eventType,
+    required PushNotificationMessage notification,
+  }) async {}
+
+  @override
+  Future<void> identifyUser({
+    required String userId,
+    UserProfile? userProfile,
+  }) async {}
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('configure() throws PushNotificationException on web', () async {
+    final plugin = TestAmplifyPushNotifications(
+      serviceProviderClient: _NoopServiceProviderClient(),
+      backgroundProcessor: () async {},
+    );
+
+    await expectLater(
+      plugin.configure(authProviderRepo: AmplifyAuthProviderRepository()),
+      throwsA(
+        isA<PushNotificationException>().having(
+          (e) => e.message,
+          'message',
+          contains('only supported on iOS and Android'),
+        ),
+      ),
+    );
+  });
+}


### PR DESCRIPTION
## Problem

Push notifications have a native implementation **only on iOS and Android** — there's no web, macOS, Windows, or Linux plugin, and push isn't part of the `amplify_flutter` umbrella (opt-in only). On any unsupported platform, `configure()` blew up with a cryptic `MissingPluginException` from the native channel calls.

## Fix

1. Guard `configure()` in the base plugin: throw a clear `PushNotificationException('Push notifications are only supported on iOS and Android.')` unless `os.isIOS || os.isAndroid`. One choke point — all providers (incl. Pinpoint) route through it. This covers web **and** desktop (macOS/Windows/Linux).
2. Declare `platforms: [ios, android]` on the base package (Pinpoint already had it) so pana reports push as mobile-only instead of inferring from the import graph.

## Notes

- Construction is already safe on all platforms (secure storage has a web impl; event channels are lazy), so the guard sits at the top of `configure()`, before the first native call.
- No new dependency. No change to the iOS/Android path.
- Uses `os_detect` (already a dependency, already used in this file) — it reliably reports the host OS on native and `BrowserOS` on web, so web/desktop are all correctly rejected.

## Verification

- VM tests for macOS/Windows/Linux/Fuchsia assert the clear exception; existing 28 VM tests pass (mobile path unaffected, driven via `overrideOperatingSystem`).
- Browser test passes under `flutter test --platform chrome` **and** `--platform chrome --wasm`.
- Verified live in a non-headless browser (dart2wasm + dart2js): plugin constructs, then `configure()` throws the clear `PushNotificationException`.