### PR TITLE
feat(sigv4): Add wasm support

### DIFF
--- a/.github/workflows/aws_signature_v4.yaml
+++ b/.github/workflows/aws_signature_v4.yaml
@@ -9,6 +9,7 @@ on:
       - '.github/composite_actions/setup_firefox/action.yaml'
       - '.github/workflows/aws_signature_v4.yaml'
       - '.github/workflows/dart_dart2js.yaml'
+      - '.github/workflows/dart_dart2wasm.yaml'
       - '.github/workflows/dart_ddc.yaml'
       - '.github/workflows/dart_native.yaml'
       - '.github/workflows/dart_vm.yaml'
@@ -25,6 +26,7 @@ on:
       - '.github/composite_actions/setup_firefox/action.yaml'
       - '.github/workflows/aws_signature_v4.yaml'
       - '.github/workflows/dart_dart2js.yaml'
+      - '.github/workflows/dart_dart2wasm.yaml'
       - '.github/workflows/dart_ddc.yaml'
       - '.github/workflows/dart_native.yaml'
       - '.github/workflows/dart_vm.yaml'
@@ -78,6 +80,13 @@ jobs:
   dart2js_test:
     needs: test
     uses: ./.github/workflows/dart_dart2js.yaml
+    secrets: inherit
+    with:
+      package-name: aws_signature_v4
+      working-directory: packages/aws_signature_v4
+  dart2wasm_test:
+    needs: test
+    uses: ./.github/workflows/dart_dart2wasm.yaml
     secrets: inherit
     with:
       package-name: aws_signature_v4

--- a/packages/aws_signature_v4/dart_test.yaml
+++ b/packages/aws_signature_v4/dart_test.yaml
@@ -1,4 +1,10 @@
+# Browser tests default to dart2js. To run under dart2wasm (opt-in), pass
+# `-c dart2wasm` on the command line, e.g.:
+#   dart test test/wasm_smoke_test.dart -p chrome -c dart2wasm
 override_platforms:
+  chrome:
+    settings:
+      arguments: --headless
   firefox:
     settings:
       arguments: -headless

--- a/packages/aws_signature_v4/test/signer_html_test.dart
+++ b/packages/aws_signature_v4/test/signer_html_test.dart
@@ -19,7 +19,10 @@ Future<void> main() async {
     final channel = spawnHybridUri('c_test_suite/c_test_suite.dart');
     final stream = StreamSplitter<dynamic>(channel.stream);
 
-    final numTests = await stream.split().first as int;
+    // The count arrives over a `spawnHybridUri` channel. Under dart2wasm,
+    // numbers cross that boundary with JS semantics (as `double`), so cast
+    // through `num` rather than directly to `int`.
+    final numTests = (await stream.split().first as num).toInt();
     final testCases = stream.split().skip(1).cast<String>().take(numTests);
 
     await for (final testCaseJson in testCases) {

--- a/packages/aws_signature_v4/test/wasm_smoke_test.dart
+++ b/packages/aws_signature_v4/test/wasm_smoke_test.dart
@@ -1,0 +1,66 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+@TestOn('browser')
+library;
+
+import 'dart:convert';
+
+import 'package:aws_common/aws_common.dart';
+import 'package:aws_signature_v4/aws_signature_v4.dart';
+import 'package:test/test.dart';
+
+/// Smoke test: proves dart2wasm compilation + browser execution works, and
+/// that the signer takes its web-specific branch (`Host`/`Content-Length` are
+/// signed but stripped from the sent headers, since browsers set them).
+///
+/// Run with: dart test test/wasm_smoke_test.dart -p chrome -c dart2wasm
+void main() {
+  group('WASM smoke test', () {
+    const signer = AWSSigV4Signer(
+      credentialsProvider: AWSCredentialsProvider(
+        AWSCredentials('accessKeyId', 'secretAccessKey'),
+      ),
+    );
+    final credentialScope = AWSCredentialScope(
+      region: 'us-east-1',
+      service: AWSService.iam,
+    );
+
+    test('zIsWeb is true on web targets', () {
+      expect(zIsWeb, isTrue, reason: 'zIsWeb must be true on web targets');
+    });
+
+    test('signs a request and produces an Authorization header', () {
+      final request = AWSHttpRequest.post(
+        Uri.https('example.com', '/'),
+        body: utf8.encode('hello'),
+        headers: const {AWSHeaders.contentLength: '5'},
+      );
+      final signed = signer.signSync(request, credentialScope: credentialScope);
+      expect(
+        signed.headers[AWSHeaders.authorization],
+        startsWith('AWS4-HMAC-SHA256'),
+      );
+    });
+
+    test('signs Host/Content-Length but strips them from sent headers', () {
+      final request = AWSHttpRequest.post(
+        Uri.https('example.com', '/'),
+        body: utf8.encode('hello'),
+        headers: const {AWSHeaders.contentLength: '5'},
+      );
+      final signed = signer.signSync(request, credentialScope: credentialScope);
+      final signedHeaders = CaseInsensitiveMap(
+        signed.canonicalRequest.canonicalHeaders,
+      );
+
+      // Signed, so they are part of the signature.
+      expect(signedHeaders, contains(AWSHeaders.host));
+      expect(signedHeaders, contains(AWSHeaders.contentLength));
+      // But not sent — the browser sets these automatically.
+      expect(signed.headers, isNot(contains(AWSHeaders.host)));
+      expect(signed.headers, isNot(contains(AWSHeaders.contentLength)));
+    });
+  });
+}


### PR DESCRIPTION
Adds dart2wasm support for `aws_signature_v4`, the SigV4 signer every AWS-signed request in the SDK flows through.

The smoke test opts the package into the dart2wasm CI leg and exercises the signer's web branch (`Host`/`Content-Length` are signed but stripped from the sent headers). Verified live in non-headless Chrome: a guest-credential-signed S3 PUT + GET round-trip against a real Gen2 sandbox is accepted by AWS (HTTP 200) under **both dart2js and dart2wasm**.