### PR TITLE
feat(smithy): Add wasm support to Smithy runtime

### DIFF
--- a/.github/workflows/smithy.yaml
+++ b/.github/workflows/smithy.yaml
@@ -6,6 +6,10 @@ on:
       - main
       - stable
     paths:
+      - '.github/composite_actions/setup_firefox/action.yaml'
+      - '.github/workflows/dart_dart2js.yaml'
+      - '.github/workflows/dart_dart2wasm.yaml'
+      - '.github/workflows/dart_ddc.yaml'
       - '.github/workflows/dart_native.yaml'
       - '.github/workflows/dart_vm.yaml'
       - '.github/workflows/smithy.yaml'
@@ -19,6 +23,10 @@ on:
       - 'packages/smithy/smithy/test/**/*'
   pull_request:
     paths:
+      - '.github/composite_actions/setup_firefox/action.yaml'
+      - '.github/workflows/dart_dart2js.yaml'
+      - '.github/workflows/dart_dart2wasm.yaml'
+      - '.github/workflows/dart_ddc.yaml'
       - '.github/workflows/dart_native.yaml'
       - '.github/workflows/dart_vm.yaml'
       - '.github/workflows/smithy.yaml'
@@ -59,6 +67,27 @@ jobs:
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     secrets: inherit 
+    with:
+      package-name: smithy
+      working-directory: packages/smithy/smithy
+  ddc_test:
+    needs: test
+    uses: ./.github/workflows/dart_ddc.yaml
+    secrets: inherit
+    with:
+      package-name: smithy
+      working-directory: packages/smithy/smithy
+  dart2js_test:
+    needs: test
+    uses: ./.github/workflows/dart_dart2js.yaml
+    secrets: inherit
+    with:
+      package-name: smithy
+      working-directory: packages/smithy/smithy
+  dart2wasm_test:
+    needs: test
+    uses: ./.github/workflows/dart_dart2wasm.yaml
+    secrets: inherit
     with:
       package-name: smithy
       working-directory: packages/smithy/smithy

--- a/.github/workflows/smithy_aws.yaml
+++ b/.github/workflows/smithy_aws.yaml
@@ -6,6 +6,10 @@ on:
       - main
       - stable
     paths:
+      - '.github/composite_actions/setup_firefox/action.yaml'
+      - '.github/workflows/dart_dart2js.yaml'
+      - '.github/workflows/dart_dart2wasm.yaml'
+      - '.github/workflows/dart_ddc.yaml'
       - '.github/workflows/dart_native.yaml'
       - '.github/workflows/dart_vm.yaml'
       - '.github/workflows/smithy_aws.yaml'
@@ -23,6 +27,10 @@ on:
       - 'packages/smithy/smithy_aws/test/**/*'
   pull_request:
     paths:
+      - '.github/composite_actions/setup_firefox/action.yaml'
+      - '.github/workflows/dart_dart2js.yaml'
+      - '.github/workflows/dart_dart2wasm.yaml'
+      - '.github/workflows/dart_ddc.yaml'
       - '.github/workflows/dart_native.yaml'
       - '.github/workflows/dart_vm.yaml'
       - '.github/workflows/smithy_aws.yaml'
@@ -67,6 +75,27 @@ jobs:
     needs: test
     uses: ./.github/workflows/dart_native.yaml
     secrets: inherit 
+    with:
+      package-name: smithy_aws
+      working-directory: packages/smithy/smithy_aws
+  ddc_test:
+    needs: test
+    uses: ./.github/workflows/dart_ddc.yaml
+    secrets: inherit
+    with:
+      package-name: smithy_aws
+      working-directory: packages/smithy/smithy_aws
+  dart2js_test:
+    needs: test
+    uses: ./.github/workflows/dart_dart2js.yaml
+    secrets: inherit
+    with:
+      package-name: smithy_aws
+      working-directory: packages/smithy/smithy_aws
+  dart2wasm_test:
+    needs: test
+    uses: ./.github/workflows/dart_dart2wasm.yaml
+    secrets: inherit
     with:
       package-name: smithy_aws
       working-directory: packages/smithy/smithy_aws

--- a/packages/smithy/smithy/dart_test.yaml
+++ b/packages/smithy/smithy/dart_test.yaml
@@ -1,4 +1,10 @@
+# Browser tests default to dart2js. To run under dart2wasm (opt-in), pass
+# `-c dart2wasm` on the command line, e.g.:
+#   dart test test/wasm_smoke_test.dart -p chrome -c dart2wasm
 override_platforms:
+  chrome:
+    settings:
+      arguments: --headless
   firefox:
     settings:
       arguments: -headless

--- a/packages/smithy/smithy/pubspec.yaml
+++ b/packages/smithy/smithy/pubspec.yaml
@@ -30,6 +30,7 @@ dependencies:
 dev_dependencies:
   amplify_lints: ">=3.1.6 <3.2.0"
   build_runner: ^2.4.15
+  build_test: ^3.1.1
   built_value_generator: ^8.10.1
   json_serializable: ^6.11.0
   stack_trace: ^1.10.0

--- a/packages/smithy/smithy/test/wasm_smoke_test.dart
+++ b/packages/smithy/smithy/test/wasm_smoke_test.dart
@@ -1,0 +1,43 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+@TestOn('browser')
+library;
+
+import 'package:aws_common/aws_common.dart';
+import 'package:smithy/smithy.dart';
+import 'package:test/test.dart';
+
+/// Smoke test: proves dart2wasm compilation + browser execution works, and
+/// that the common interceptors take their web-specific branch — `Host` and
+/// `Content-Length` are omitted from the request, since browsers set them
+/// automatically and forbid setting them from script.
+///
+/// Run with: dart test test/wasm_smoke_test.dart -p chrome -c dart2wasm
+void main() {
+  group('WASM smoke test', () {
+    test('zIsWeb is true on web targets', () {
+      expect(zIsWeb, isTrue, reason: 'zIsWeb must be true on web targets');
+    });
+
+    test('WithHost does not set the Host header on web', () {
+      const interceptor = WithHost();
+      final request = AWSHttpRequest.get(Uri.https('example.com', '/'));
+      interceptor.intercept(request);
+      expect(request.headers, isNot(contains(AWSHeaders.host)));
+    });
+
+    test(
+      'WithContentLength does not set the Content-Length header on web',
+      () async {
+        const interceptor = WithContentLength();
+        final request = AWSHttpRequest.post(
+          Uri.https('example.com', '/'),
+          body: 'hello'.codeUnits,
+        );
+        await interceptor.intercept(request);
+        expect(request.headers, isNot(contains(AWSHeaders.contentLength)));
+      },
+    );
+  });
+}

--- a/packages/smithy/smithy_aws/dart_test.yaml
+++ b/packages/smithy/smithy_aws/dart_test.yaml
@@ -1,4 +1,10 @@
+# Browser tests default to dart2js. To run under dart2wasm (opt-in), pass
+# `-c dart2wasm` on the command line, e.g.:
+#   dart test test/wasm_smoke_test.dart -p chrome -c dart2wasm
 override_platforms:
+  chrome:
+    settings:
+      arguments: --headless
   firefox:
     settings:
       arguments: -headless

--- a/packages/smithy/smithy_aws/pubspec.yaml
+++ b/packages/smithy/smithy_aws/pubspec.yaml
@@ -27,6 +27,7 @@ dependencies:
 dev_dependencies:
   amplify_lints: ">=3.1.6 <3.2.0"
   build_runner: ^2.4.15
+  build_test: ^3.1.1
   built_value_generator: ^8.10.1
   file: ^7.0.1
   glob: ^2.1.0

--- a/packages/smithy/smithy_aws/test/wasm_smoke_test.dart
+++ b/packages/smithy/smithy_aws/test/wasm_smoke_test.dart
@@ -1,0 +1,48 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+@TestOn('browser')
+library;
+
+import 'package:aws_common/aws_common.dart';
+import 'package:smithy/smithy.dart';
+import 'package:smithy_aws/smithy_aws.dart';
+import 'package:test/test.dart';
+
+/// Smoke test: proves the `smithy_aws` runtime compiles and runs under
+/// dart2wasm in a browser. `smithy_aws` has no web-specific branch of its own,
+/// so this exercises its core runtime types — the retry policy, endpoint, and
+/// credential-scope serialization — which run on web underneath every AWS
+/// service client.
+void main() {
+  group('WASM smoke test', () {
+    test('zIsWeb is true on web targets', () {
+      expect(zIsWeb, isTrue, reason: 'zIsWeb must be true on web targets');
+    });
+
+    test('AWSRetryer can be constructed with its defaults', () {
+      final retryer = AWSRetryer();
+      expect(retryer.initialRetryTokens, greaterThan(0));
+      expect(retryer.maxBackoffTime, isA<Duration>());
+    });
+
+    test('CredentialScope round-trips through JSON', () {
+      const scope = CredentialScope(region: 'us-east-1', service: 's3');
+      final decoded = CredentialScope.fromJson(scope.toJson());
+      expect(decoded.region, 'us-east-1');
+      expect(decoded.service, 's3');
+    });
+
+    test('AWSEndpoint holds its endpoint and credential scope', () {
+      final endpoint = AWSEndpoint(
+        endpoint: Endpoint(uri: Uri.https('s3.us-east-1.amazonaws.com')),
+        credentialScope: const CredentialScope(
+          region: 'us-east-1',
+          service: 's3',
+        ),
+      );
+      expect(endpoint.endpoint.uri.host, 's3.us-east-1.amazonaws.com');
+      expect(endpoint.credentialScope?.region, 'us-east-1');
+    });
+  });
+}


### PR DESCRIPTION
Adds dart2wasm browser coverage to the Smithy runtime component — `smithy` and `smithy_aws` — the client runtime every generated AWS SDK client depends on at runtime (Cognito, S3, etc.). They're one aft component and versioned together, so both land here.

- Adds `build_test` + `build_web_compilers` and a `test/wasm_smoke_test.dart` to each, opting into the `dart2wasm` job.
  - `smithy`: covers the web-conditional interceptors (`WithHost` / `WithContentLength` omit `Host`/`Content-Length` on web).
  - `smithy_aws`: no web-specific branch of its own, so the smoke test exercises core runtime types (retryer, endpoint, credential-scope serialization) under wasm.
- Neither package had a browser job before, so this also enables the ddc + dart2js jobs (regenerated via `aft generate workflows`).
- Full suites pass locally under ddc, dart2js, and dart2wasm.

Verified end-to-end against a live Gen2 sandbox: guest-credential fetch (generated CognitoIdentity smithy client — GetId + GetCredentialsForIdentity, which runs through both packages) passes under dart2js and dart2wasm in a real browser.