### PR TITLE
fix(auth): Don't generate unused `JsonWebKeySet.fromJson`

### DIFF
--- a/packages/auth/amplify_auth_cognito_dart/lib/src/jwt/src/keyset.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/jwt/src/keyset.dart
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'package:amplify_auth_cognito_dart/src/jwt/src/key.dart';
-import 'package:amplify_auth_cognito_dart/src/jwt/src/prefs.dart';
 import 'package:aws_common/aws_common.dart';
+import 'package:json_annotation/json_annotation.dart';
 import 'package:meta/meta.dart';
 
 part 'keyset.g.dart';
@@ -13,7 +13,12 @@ part 'keyset.g.dart';
 /// [JsonWebKey]s.
 /// {@endtemplate}
 @immutable
-@jwtSerializable
+// [fromJson] is hand-written to skip unparseable keys.
+@JsonSerializable(
+  includeIfNull: false,
+  explicitToJson: true,
+  createFactory: false,
+)
 class JsonWebKeySet with AWSEquatable<JsonWebKeySet>, AWSSerializable {
   /// {@macro amplify_auth_cognito.json_web_key_set}
   const JsonWebKeySet(this.keys);
@@ -46,6 +51,7 @@ class JsonWebKeySet with AWSEquatable<JsonWebKeySet>, AWSSerializable {
   final List<JsonWebKey> keys;
 
   @override
+  @JsonKey(includeToJson: false)
   List<Object?> get props => [keys];
 
   @override

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/jwt/src/keyset.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/jwt/src/keyset.g.dart
@@ -6,12 +6,5 @@ part of 'keyset.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-JsonWebKeySet _$JsonWebKeySetFromJson(Map<String, dynamic> json) =>
-    JsonWebKeySet(
-      (json['keys'] as List<dynamic>)
-          .map((e) => JsonWebKey.fromJson(e as Map<String, dynamic>))
-          .toList(),
-    );
-
 Map<String, dynamic> _$JsonWebKeySetToJson(JsonWebKeySet instance) =>
     <String, dynamic>{'keys': instance.keys.map((e) => e.toJson()).toList()};


### PR DESCRIPTION
`JsonWebKeySet` has a hand-written `fromJson` (it skips unparseable keys), so the generated `_\$JsonWebKeySetFromJson` was never referenced and flagged as `unused_element` by `lints_core` on pub.dev.

Set `createFactory: false` on the class and exclude `props` from `toJson`, leaving the generated `toJson` unchanged.

Addresses this:
<img width="500" alt="Screenshot 2026-07-28 at 14 53 41" src="https://github.com/user-attachments/assets/3a662594-226b-4de5-a106-78d18f7ee032" />
(https://pub.dev/packages/amplify_auth_cognito_dart/score)