### PR TITLE
feat(authenticator): Add wasm support

### DIFF
--- a/packages/authenticator/amplify_authenticator/lib/src/state/auth_state.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/state/auth_state.dart
@@ -3,9 +3,9 @@
 
 import 'package:amplify_authenticator/src/enums/authenticator_step.dart';
 import 'package:amplify_authenticator/src/models/totp_options.dart';
+import 'package:amplify_authenticator/src/utils/package_info/package_info.dart';
 import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:flutter/foundation.dart';
-import 'package:package_info_plus/package_info_plus.dart';
 
 abstract class AuthState {
   const AuthState();
@@ -146,7 +146,7 @@ class ContinueSignInTotpSetup extends UnauthenticatedState {
       appName:
           totpOptions?.issuer ??
           // TODO(equartey): Update this once we have our own method of getting the app name
-          (await PackageInfo.fromPlatform()).appName,
+          await getAppName(),
     );
 
     return ContinueSignInTotpSetup(totpSetupDetails, setupUri);

--- a/packages/authenticator/amplify_authenticator/lib/src/utils/package_info/package_info.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/utils/package_info/package_info.dart
@@ -1,0 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export 'package_info_stub.dart'
+    if (dart.library.js_interop) 'package_info_html.dart'
+    if (dart.library.io) 'package_info_io.dart';

--- a/packages/authenticator/amplify_authenticator/lib/src/utils/package_info/package_info_html.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/utils/package_info/package_info_html.dart
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:package_info_plus_platform_interface/package_info_platform_interface.dart';
+
+/// {@macro amplify_authenticator.get_app_name}
+///
+/// Reads from [PackageInfoPlatform.instance], which the `package_info_plus`
+/// web plugin registers. Importing only the platform interface (not the
+/// `package_info_plus` entrypoint) keeps `dart:io` out of the web build.
+Future<String> getAppName() async {
+  final info = await PackageInfoPlatform.instance.getAll();
+  return info.appName;
+}

--- a/packages/authenticator/amplify_authenticator/lib/src/utils/package_info/package_info_io.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/utils/package_info/package_info_io.dart
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:package_info_plus/package_info_plus.dart';
+
+/// {@macro amplify_authenticator.get_app_name}
+Future<String> getAppName() async {
+  final info = await PackageInfo.fromPlatform();
+  return info.appName;
+}

--- a/packages/authenticator/amplify_authenticator/lib/src/utils/package_info/package_info_stub.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/utils/package_info/package_info_stub.dart
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/// {@template amplify_authenticator.get_app_name}
+/// Returns the current application's name.
+///
+/// Split by platform so the web build never imports `package_info_plus`, which
+/// transitively pulls in `dart:io` and breaks wasm compatibility.
+/// {@endtemplate}
+Future<String> getAppName() async {
+  throw UnsupportedError(
+    'No suitable implementation was found on this platform.',
+  );
+}

--- a/packages/authenticator/amplify_authenticator/pubspec.yaml
+++ b/packages/authenticator/amplify_authenticator/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   meta: ^1.16.0
   # TODO(equartey): Remove this once we have our own method of getting the app name
   package_info_plus: ^10.1.0
+  package_info_plus_platform_interface: ^4.1.0
   qr_flutter: 4.1.0
   smithy: ">=0.7.12 <0.8.0"
   stream_transform: ^2.1.0


### PR DESCRIPTION
`amplify_authenticator` is flagged as not WASM-compatible on pub.dev because `auth_state.dart` imports `package_info_plus`, whose entrypoint unconditionally exports its `dart:io`-backed Linux implementation.

Splits the app-name lookup behind conditional imports (same pattern as `amplify_analytics_pinpoint` in #7162): web reads from `package_info_plus_platform_interface` (no `dart:io`), VM keeps using `package_info_plus`.

Verified with `pana`: `is:wasm-ready` is absent before the change and present after.