### PR TITLE
chore(android): Modernize Android toolchain (Gradle 8.14 / KGP 2.2.20 / AGP 8.11.1)

### DIFF
--- a/build-support/build_canary.sh
+++ b/build-support/build_canary.sh
@@ -48,7 +48,7 @@ sed -i '' -e "s/compileOptions {.*/compileOptions {\n\t\tisCoreLibraryDesugaring
 sed -i '' -e "s/flutter {.*/dependencies {\n\tcoreLibraryDesugaring(\"com.android.tools:desugar_jdk_libs:2.1.5\")\n}\n\nflutter {/" ./android/app/build.gradle.kts
 cat ./android/app/build.gradle.kts
 
-sed -i '' -e "s#distributionUrl=.*#distributionUrl=https\\://services.gradle.org/distributions/gradle-8.13-all.zip#" ./android/gradle/wrapper/gradle-wrapper.properties
+sed -i '' -e "s#distributionUrl=.*#distributionUrl=https\\://services.gradle.org/distributions/gradle-8.14-all.zip#" ./android/gradle/wrapper/gradle-wrapper.properties
 cat ./android/gradle/wrapper/gradle-wrapper.properties
 
 

--- a/build-support/build_canary.sh
+++ b/build-support/build_canary.sh
@@ -24,8 +24,8 @@ cp -r $ROOT_DIR/canaries/lib .
 cp $ROOT_DIR/build-support/dummy_amplifyconfiguration.dart lib/amplifyconfiguration.dart
 
 # Android
-sed -i '' -e "s/id(\"com.android.application\") .*/id(\"com.android.application\") version \"8.12.1\" apply false/" ./android/settings.gradle.kts
-sed -i '' -e "s/id(\"org.jetbrains.kotlin.android\") .*/id(\"org.jetbrains.kotlin.android\") version \"2.2.0\" apply false/" ./android/settings.gradle.kts
+sed -i '' -e "s/id(\"com.android.application\") .*/id(\"com.android.application\") version \"8.11.1\" apply false/" ./android/settings.gradle.kts
+sed -i '' -e "s/id(\"org.jetbrains.kotlin.android\") .*/id(\"org.jetbrains.kotlin.android\") version \"2.2.20\" apply false/" ./android/settings.gradle.kts
 cat ./android/settings.gradle.kts
 
 # TODO(khatruong2009): remove this line after the next stable release (3.22.0 or 4.0)

--- a/canaries/android/gradle/wrapper/gradle-wrapper.properties
+++ b/canaries/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip

--- a/canaries/android/settings.gradle
+++ b/canaries/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.12.1" apply false
-    id "org.jetbrains.kotlin.android" version "2.2.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 
 include ":app"

--- a/canaries/android/settings.gradle
+++ b/canaries/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.12.1" apply false
+    id "com.android.application" version "8.11.1" apply false
     id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 

--- a/packages/amplify/amplify_flutter/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/amplify/amplify_flutter/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip

--- a/packages/amplify/amplify_flutter/example/android/settings.gradle
+++ b/packages/amplify/amplify_flutter/example/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.12.1" apply false
-    id "org.jetbrains.kotlin.android" version "2.2.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 
 include ":app"

--- a/packages/amplify/amplify_flutter/example/android/settings.gradle
+++ b/packages/amplify/amplify_flutter/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.12.1" apply false
+    id "com.android.application" version "8.11.1" apply false
     id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 

--- a/packages/amplify_datastore/android/build.gradle
+++ b/packages/amplify_datastore/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.13.0'
+        classpath 'com.android.tools.build:gradle:8.11.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'org.jlleitschuh.gradle:ktlint-gradle:14.2.0'
     }

--- a/packages/amplify_datastore/android/build.gradle
+++ b/packages/amplify_datastore/android/build.gradle
@@ -2,7 +2,6 @@ group 'com.amazonaws.amplify.amplify_datastore'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '2.2.20'
     repositories {
         mavenLocal()
         google()
@@ -14,7 +13,6 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:8.11.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'org.jlleitschuh.gradle:ktlint-gradle:14.2.0'
     }
 }
@@ -28,7 +26,12 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+
+def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
+if (agpMajor < 9) {
+    apply plugin: 'kotlin-android'
+}
+
 apply plugin: 'kotlin-parcelize'
 apply plugin: 'org.jlleitschuh.gradle.ktlint'
 
@@ -59,10 +62,6 @@ android {
 
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
-    }
-    
-    kotlinOptions {
-        jvmTarget = '17'
     }
 
     testOptions {
@@ -97,4 +96,10 @@ dependencies {
     testImplementation 'com.fasterxml.jackson.core:jackson-core:2.22.0'
     testImplementation 'com.fasterxml.jackson.core:jackson-annotations:2.22'
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.22.0'
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+    }
 }

--- a/packages/amplify_datastore/android/build.gradle
+++ b/packages/amplify_datastore/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.amazonaws.amplify.amplify_datastore'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '2.2.0'
+    ext.kotlin_version = '2.2.20'
     repositories {
         mavenLocal()
         google()

--- a/packages/amplify_datastore/android/build.gradle
+++ b/packages/amplify_datastore/android/build.gradle
@@ -27,8 +27,14 @@ rootProject.allprojects {
 
 apply plugin: 'com.android.library'
 
+// Apply the Kotlin plugin unless the consuming app has AGP's built-in Kotlin
+// enabled (AGP 9+ with android.builtInKotlin=true), where applying it is an
+// error. This keeps already-released versions of this package building across
+// a future Flutter that turns built-in Kotlin on. Fully dropping the apply
+// (built-in Kotlin migration, #7014) lands once the Flutter floor is 3.47+.
 def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
-if (agpMajor < 9) {
+def builtInKotlin = project.findProperty('android.builtInKotlin')?.toString()?.toBoolean() ?: false
+if (agpMajor < 9 || !builtInKotlin) {
     apply plugin: 'kotlin-android'
 }
 

--- a/packages/amplify_datastore/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/amplify_datastore/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/packages/amplify_datastore/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/amplify_datastore/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip

--- a/packages/amplify_datastore/example/android/settings.gradle
+++ b/packages/amplify_datastore/example/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.12.1" apply false
-    id "org.jetbrains.kotlin.android" version "2.2.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 
 include ":app"

--- a/packages/amplify_datastore/example/android/settings.gradle
+++ b/packages/amplify_datastore/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.12.1" apply false
+    id "com.android.application" version "8.11.1" apply false
     id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 

--- a/packages/amplify_native_legacy_wrapper/android/build.gradle
+++ b/packages/amplify_native_legacy_wrapper/android/build.gradle
@@ -2,7 +2,6 @@ group 'com.amazonaws.amplify.amplify_native_legacy_wrapper'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '2.2.20'
     repositories {
         google()
         mavenCentral()
@@ -10,7 +9,6 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:8.11.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
@@ -22,7 +20,11 @@ allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+
+def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
+if (agpMajor < 9) {
+    apply plugin: 'kotlin-android'
+}
 
 android {
     compileSdk 36
@@ -30,10 +32,6 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = '17'
     }
 
     sourceSets {
@@ -50,4 +48,10 @@ dependencies {
     implementation 'com.amplifyframework:core:1.38.6'
     implementation 'com.amplifyframework:core-kotlin:0.22.8'
     implementation 'com.amplifyframework:aws-auth-cognito:1.38.6'
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+    }
 }

--- a/packages/amplify_native_legacy_wrapper/android/build.gradle
+++ b/packages/amplify_native_legacy_wrapper/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.amazonaws.amplify.amplify_native_legacy_wrapper'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '2.2.0'
+    ext.kotlin_version = '2.2.20'
     repositories {
         google()
         mavenCentral()

--- a/packages/amplify_native_legacy_wrapper/android/build.gradle
+++ b/packages/amplify_native_legacy_wrapper/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.12.1'
+        classpath 'com.android.tools.build:gradle:8.11.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/packages/amplify_native_legacy_wrapper/android/build.gradle
+++ b/packages/amplify_native_legacy_wrapper/android/build.gradle
@@ -21,8 +21,14 @@ allprojects {
 
 apply plugin: 'com.android.library'
 
+// Apply the Kotlin plugin unless the consuming app has AGP's built-in Kotlin
+// enabled (AGP 9+ with android.builtInKotlin=true), where applying it is an
+// error. This keeps already-released versions of this package building across
+// a future Flutter that turns built-in Kotlin on. Fully dropping the apply
+// (built-in Kotlin migration, #7014) lands once the Flutter floor is 3.47+.
 def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
-if (agpMajor < 9) {
+def builtInKotlin = project.findProperty('android.builtInKotlin')?.toString()?.toBoolean() ?: false
+if (agpMajor < 9 || !builtInKotlin) {
     apply plugin: 'kotlin-android'
 }
 

--- a/packages/amplify_native_legacy_wrapper/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/amplify_native_legacy_wrapper/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip

--- a/packages/amplify_native_legacy_wrapper/example/android/settings.gradle
+++ b/packages/amplify_native_legacy_wrapper/example/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.12.1" apply false
-    id "org.jetbrains.kotlin.android" version "2.2.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 
 include ":app"

--- a/packages/amplify_native_legacy_wrapper/example/android/settings.gradle
+++ b/packages/amplify_native_legacy_wrapper/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.12.1" apply false
+    id "com.android.application" version "8.11.1" apply false
     id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 

--- a/packages/analytics/amplify_analytics_pinpoint/android/build.gradle
+++ b/packages/analytics/amplify_analytics_pinpoint/android/build.gradle
@@ -10,7 +10,6 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:8.11.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
@@ -22,7 +21,11 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+
+def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
+if (agpMajor < 9) {
+    apply plugin: 'kotlin-android'
+}
 
 android {
     compileSdk 36
@@ -30,10 +33,6 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = '17'
     }
 
     sourceSets {
@@ -51,3 +50,8 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+    }
+}

--- a/packages/analytics/amplify_analytics_pinpoint/android/build.gradle
+++ b/packages/analytics/amplify_analytics_pinpoint/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.amazonaws.amplify.amplify_analytics_pinpoint'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '2.2.0'
+    ext.kotlin_version = '2.2.20'
     repositories {
         google()
         mavenCentral()

--- a/packages/analytics/amplify_analytics_pinpoint/android/build.gradle
+++ b/packages/analytics/amplify_analytics_pinpoint/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.12.1'
+        classpath 'com.android.tools.build:gradle:8.11.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/packages/analytics/amplify_analytics_pinpoint/android/build.gradle
+++ b/packages/analytics/amplify_analytics_pinpoint/android/build.gradle
@@ -22,8 +22,14 @@ rootProject.allprojects {
 
 apply plugin: 'com.android.library'
 
+// Apply the Kotlin plugin unless the consuming app has AGP's built-in Kotlin
+// enabled (AGP 9+ with android.builtInKotlin=true), where applying it is an
+// error. This keeps already-released versions of this package building across
+// a future Flutter that turns built-in Kotlin on. Fully dropping the apply
+// (built-in Kotlin migration, #7014) lands once the Flutter floor is 3.47+.
 def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
-if (agpMajor < 9) {
+def builtInKotlin = project.findProperty('android.builtInKotlin')?.toString()?.toBoolean() ?: false
+if (agpMajor < 9 || !builtInKotlin) {
     apply plugin: 'kotlin-android'
 }
 

--- a/packages/analytics/amplify_analytics_pinpoint/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/analytics/amplify_analytics_pinpoint/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip

--- a/packages/analytics/amplify_analytics_pinpoint/example/android/settings.gradle
+++ b/packages/analytics/amplify_analytics_pinpoint/example/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.12.1" apply false
-    id "org.jetbrains.kotlin.android" version "2.2.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 
 include ":app"

--- a/packages/analytics/amplify_analytics_pinpoint/example/android/settings.gradle
+++ b/packages/analytics/amplify_analytics_pinpoint/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.12.1" apply false
+    id "com.android.application" version "8.11.1" apply false
     id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 

--- a/packages/api/amplify_api/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/api/amplify_api/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip

--- a/packages/api/amplify_api/example/android/settings.gradle
+++ b/packages/api/amplify_api/example/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.12.1" apply false
-    id "org.jetbrains.kotlin.android" version "2.2.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 
 include ":app"

--- a/packages/api/amplify_api/example/android/settings.gradle
+++ b/packages/api/amplify_api/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.12.1" apply false
+    id "com.android.application" version "8.11.1" apply false
     id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 

--- a/packages/auth/amplify_auth_cognito/android/build.gradle
+++ b/packages/auth/amplify_auth_cognito/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.amazonaws.amplify.amplify_auth_cognito'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '2.2.0'
+    ext.kotlin_version = '2.2.20'
     repositories {
         google()
         mavenCentral()

--- a/packages/auth/amplify_auth_cognito/android/build.gradle
+++ b/packages/auth/amplify_auth_cognito/android/build.gradle
@@ -2,7 +2,6 @@ group 'com.amazonaws.amplify.amplify_auth_cognito'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '2.2.20'
     repositories {
         google()
         mavenCentral()
@@ -10,7 +9,6 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:8.11.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
@@ -22,7 +20,11 @@ allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+
+def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
+if (agpMajor < 9) {
+    apply plugin: 'kotlin-android'
+}
 
 android {
     compileSdk 36
@@ -30,10 +32,6 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = '17'
     }
 
     sourceSets {
@@ -64,4 +62,10 @@ dependencies {
     testImplementation 'androidx.test:core:1.7.0'
     testImplementation 'org.robolectric:robolectric:4.15.1'
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2'
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+    }
 }

--- a/packages/auth/amplify_auth_cognito/android/build.gradle
+++ b/packages/auth/amplify_auth_cognito/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.12.1'
+        classpath 'com.android.tools.build:gradle:8.11.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/packages/auth/amplify_auth_cognito/android/build.gradle
+++ b/packages/auth/amplify_auth_cognito/android/build.gradle
@@ -21,8 +21,14 @@ allprojects {
 
 apply plugin: 'com.android.library'
 
+// Apply the Kotlin plugin unless the consuming app has AGP's built-in Kotlin
+// enabled (AGP 9+ with android.builtInKotlin=true), where applying it is an
+// error. This keeps already-released versions of this package building across
+// a future Flutter that turns built-in Kotlin on. Fully dropping the apply
+// (built-in Kotlin migration, #7014) lands once the Flutter floor is 3.47+.
 def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
-if (agpMajor < 9) {
+def builtInKotlin = project.findProperty('android.builtInKotlin')?.toString()?.toBoolean() ?: false
+if (agpMajor < 9 || !builtInKotlin) {
     apply plugin: 'kotlin-android'
 }
 

--- a/packages/auth/amplify_auth_cognito/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/auth/amplify_auth_cognito/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip

--- a/packages/auth/amplify_auth_cognito/example/android/settings.gradle
+++ b/packages/auth/amplify_auth_cognito/example/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.12.1" apply false
-    id "org.jetbrains.kotlin.android" version "2.2.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 
 include ":app"

--- a/packages/auth/amplify_auth_cognito/example/android/settings.gradle
+++ b/packages/auth/amplify_auth_cognito/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.12.1" apply false
+    id "com.android.application" version "8.11.1" apply false
     id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 

--- a/packages/authenticator/amplify_authenticator/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/authenticator/amplify_authenticator/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip

--- a/packages/authenticator/amplify_authenticator/example/android/settings.gradle
+++ b/packages/authenticator/amplify_authenticator/example/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.12.1" apply false
-    id "org.jetbrains.kotlin.android" version "2.2.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 
 include ":app"

--- a/packages/authenticator/amplify_authenticator/example/android/settings.gradle
+++ b/packages/authenticator/amplify_authenticator/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.12.1" apply false
+    id "com.android.application" version "8.11.1" apply false
     id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 

--- a/packages/authenticator/amplify_authenticator_test/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/authenticator/amplify_authenticator_test/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip

--- a/packages/authenticator/amplify_authenticator_test/example/android/settings.gradle
+++ b/packages/authenticator/amplify_authenticator_test/example/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.12.1" apply false
-    id "org.jetbrains.kotlin.android" version "2.2.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 
 include ":app"

--- a/packages/authenticator/amplify_authenticator_test/example/android/settings.gradle
+++ b/packages/authenticator/amplify_authenticator_test/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.12.1" apply false
+    id "com.android.application" version "8.11.1" apply false
     id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 

--- a/packages/common/amplify_db_common/android/build.gradle
+++ b/packages/common/amplify_db_common/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.amazonaws.amplify.amplify_db_common'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '2.2.0'
+    ext.kotlin_version = '2.2.20'
     repositories {
         google()
         mavenCentral()

--- a/packages/common/amplify_db_common/android/build.gradle
+++ b/packages/common/amplify_db_common/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.12.1'
+        classpath 'com.android.tools.build:gradle:8.11.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/packages/common/amplify_db_common/android/build.gradle
+++ b/packages/common/amplify_db_common/android/build.gradle
@@ -2,7 +2,6 @@ group 'com.amazonaws.amplify.amplify_db_common'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '2.2.20'
     repositories {
         google()
         mavenCentral()
@@ -10,7 +9,6 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:8.11.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
@@ -22,7 +20,11 @@ allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+
+def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
+if (agpMajor < 9) {
+    apply plugin: 'kotlin-android'
+}
 
 android {
     compileSdk 36
@@ -30,10 +32,6 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = '17'
     }
 
     sourceSets {
@@ -50,4 +48,10 @@ android {
 dependencies {
     // Keep in sync with: https://github.com/simolus3/sqlite3.dart/blob/main/sqlite3_flutter_libs/android/build.gradle
     implementation 'eu.simonbinder:sqlite3-native-library:3.51.2'
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+    }
 }

--- a/packages/common/amplify_db_common/android/build.gradle
+++ b/packages/common/amplify_db_common/android/build.gradle
@@ -21,8 +21,14 @@ allprojects {
 
 apply plugin: 'com.android.library'
 
+// Apply the Kotlin plugin unless the consuming app has AGP's built-in Kotlin
+// enabled (AGP 9+ with android.builtInKotlin=true), where applying it is an
+// error. This keeps already-released versions of this package building across
+// a future Flutter that turns built-in Kotlin on. Fully dropping the apply
+// (built-in Kotlin migration, #7014) lands once the Flutter floor is 3.47+.
 def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
-if (agpMajor < 9) {
+def builtInKotlin = project.findProperty('android.builtInKotlin')?.toString()?.toBoolean() ?: false
+if (agpMajor < 9 || !builtInKotlin) {
     apply plugin: 'kotlin-android'
 }
 

--- a/packages/common/amplify_db_common/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/common/amplify_db_common/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip

--- a/packages/common/amplify_db_common/example/android/settings.gradle
+++ b/packages/common/amplify_db_common/example/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.12.1" apply false
-    id "org.jetbrains.kotlin.android" version "2.2.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 
 include ":app"

--- a/packages/common/amplify_db_common/example/android/settings.gradle
+++ b/packages/common/amplify_db_common/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.12.1" apply false
+    id "com.android.application" version "8.11.1" apply false
     id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 

--- a/packages/notifications/push/amplify_push_notifications/android/build.gradle
+++ b/packages/notifications/push/amplify_push_notifications/android/build.gradle
@@ -27,7 +27,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlinx-serialization'
 
 android {
-    compileSdk 35
+    compileSdk 36
 
     compileOptions {
         coreLibraryDesugaringEnabled true

--- a/packages/notifications/push/amplify_push_notifications/android/build.gradle
+++ b/packages/notifications/push/amplify_push_notifications/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.13.0'
+        classpath 'com.android.tools.build:gradle:8.11.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
     }

--- a/packages/notifications/push/amplify_push_notifications/android/build.gradle
+++ b/packages/notifications/push/amplify_push_notifications/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.amazonaws.amplify.amplify_push_notifications'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '2.2.0'
+    ext.kotlin_version = '2.2.20'
     repositories {
         google()
         mavenCentral()

--- a/packages/notifications/push/amplify_push_notifications/android/build.gradle
+++ b/packages/notifications/push/amplify_push_notifications/android/build.gradle
@@ -10,7 +10,6 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:8.11.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
     }
 }
@@ -23,7 +22,12 @@ allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+
+def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
+if (agpMajor < 9) {
+    apply plugin: 'kotlin-android'
+}
+
 apply plugin: 'kotlinx-serialization'
 
 android {
@@ -34,10 +38,6 @@ android {
 
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = '17'
     }
 
     sourceSets {
@@ -85,4 +85,10 @@ dependencies {
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2'
     testImplementation 'androidx.work:work-testing:2.10.1'
 
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+    }
 }

--- a/packages/notifications/push/amplify_push_notifications/android/build.gradle
+++ b/packages/notifications/push/amplify_push_notifications/android/build.gradle
@@ -23,8 +23,14 @@ allprojects {
 
 apply plugin: 'com.android.library'
 
+// Apply the Kotlin plugin unless the consuming app has AGP's built-in Kotlin
+// enabled (AGP 9+ with android.builtInKotlin=true), where applying it is an
+// error. This keeps already-released versions of this package building across
+// a future Flutter that turns built-in Kotlin on. Fully dropping the apply
+// (built-in Kotlin migration, #7014) lands once the Flutter floor is 3.47+.
 def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
-if (agpMajor < 9) {
+def builtInKotlin = project.findProperty('android.builtInKotlin')?.toString()?.toBoolean() ?: false
+if (agpMajor < 9 || !builtInKotlin) {
     apply plugin: 'kotlin-android'
 }
 

--- a/packages/notifications/push/amplify_push_notifications/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/notifications/push/amplify_push_notifications/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/packages/notifications/push/amplify_push_notifications/example/android/settings.gradle
+++ b/packages/notifications/push/amplify_push_notifications/example/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.12.1" apply false
-    id "org.jetbrains.kotlin.android" version "2.2.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 
 include ":app"

--- a/packages/notifications/push/amplify_push_notifications/example/android/settings.gradle
+++ b/packages/notifications/push/amplify_push_notifications/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.12.1" apply false
+    id "com.android.application" version "8.11.1" apply false
     id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 

--- a/packages/notifications/push/amplify_push_notifications_pinpoint/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/notifications/push/amplify_push_notifications_pinpoint/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip

--- a/packages/notifications/push/amplify_push_notifications_pinpoint/example/android/settings.gradle
+++ b/packages/notifications/push/amplify_push_notifications_pinpoint/example/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.12.1" apply false
-    id "org.jetbrains.kotlin.android" version "2.2.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
     
     id "com.google.gms.google-services" version "4.3.14" apply false
 }

--- a/packages/notifications/push/amplify_push_notifications_pinpoint/example/android/settings.gradle
+++ b/packages/notifications/push/amplify_push_notifications_pinpoint/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.12.1" apply false
+    id "com.android.application" version "8.11.1" apply false
     id "org.jetbrains.kotlin.android" version "2.2.20" apply false
     
     id "com.google.gms.google-services" version "4.3.14" apply false

--- a/packages/secure_storage/amplify_secure_storage/android/build.gradle
+++ b/packages/secure_storage/amplify_secure_storage/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.amazonaws.amplify.amplify_secure_storage'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '2.2.0'
+    ext.kotlin_version = '2.2.20'
     repositories {
         google()
         mavenCentral()

--- a/packages/secure_storage/amplify_secure_storage/android/build.gradle
+++ b/packages/secure_storage/amplify_secure_storage/android/build.gradle
@@ -10,7 +10,6 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:8.11.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
@@ -22,7 +21,11 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+
+def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
+if (agpMajor < 9) {
+    apply plugin: 'kotlin-android'
+}
 
 android {
     compileSdk 36
@@ -30,10 +33,6 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = '17'
     }
 
     sourceSets {
@@ -58,4 +57,10 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.robolectric:robolectric:4.16.1'
     testImplementation 'androidx.test:core-ktx:1.7.0'
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+    }
 }

--- a/packages/secure_storage/amplify_secure_storage/android/build.gradle
+++ b/packages/secure_storage/amplify_secure_storage/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.12.1'
+        classpath 'com.android.tools.build:gradle:8.11.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/packages/secure_storage/amplify_secure_storage/android/build.gradle
+++ b/packages/secure_storage/amplify_secure_storage/android/build.gradle
@@ -22,8 +22,14 @@ rootProject.allprojects {
 
 apply plugin: 'com.android.library'
 
+// Apply the Kotlin plugin unless the consuming app has AGP's built-in Kotlin
+// enabled (AGP 9+ with android.builtInKotlin=true), where applying it is an
+// error. This keeps already-released versions of this package building across
+// a future Flutter that turns built-in Kotlin on. Fully dropping the apply
+// (built-in Kotlin migration, #7014) lands once the Flutter floor is 3.47+.
 def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
-if (agpMajor < 9) {
+def builtInKotlin = project.findProperty('android.builtInKotlin')?.toString()?.toBoolean() ?: false
+if (agpMajor < 9 || !builtInKotlin) {
     apply plugin: 'kotlin-android'
 }
 

--- a/packages/secure_storage/amplify_secure_storage/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/secure_storage/amplify_secure_storage/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip

--- a/packages/secure_storage/amplify_secure_storage/example/android/settings.gradle
+++ b/packages/secure_storage/amplify_secure_storage/example/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.12.1" apply false
-    id "org.jetbrains.kotlin.android" version "2.2.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 
 include ":app"

--- a/packages/secure_storage/amplify_secure_storage/example/android/settings.gradle
+++ b/packages/secure_storage/amplify_secure_storage/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.12.1" apply false
+    id "com.android.application" version "8.11.1" apply false
     id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 

--- a/packages/storage/amplify_storage_s3/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/storage/amplify_storage_s3/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip

--- a/packages/storage/amplify_storage_s3/example/android/settings.gradle
+++ b/packages/storage/amplify_storage_s3/example/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.12.1" apply false
-    id "org.jetbrains.kotlin.android" version "2.2.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 
 include ":app"

--- a/packages/storage/amplify_storage_s3/example/android/settings.gradle
+++ b/packages/storage/amplify_storage_s3/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.12.1" apply false
+    id "com.android.application" version "8.11.1" apply false
     id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 

--- a/packages/worker_bee/e2e_flutter_test/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/worker_bee/e2e_flutter_test/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip

--- a/packages/worker_bee/e2e_flutter_test/android/settings.gradle
+++ b/packages/worker_bee/e2e_flutter_test/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.12.1" apply false
-    id "org.jetbrains.kotlin.android" version "2.2.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 
 include ":app"

--- a/packages/worker_bee/e2e_flutter_test/android/settings.gradle
+++ b/packages/worker_bee/e2e_flutter_test/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.12.1" apply false
+    id "com.android.application" version "8.11.1" apply false
     id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 

--- a/templates/flutter-package/__brick__/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/templates/flutter-package/__brick__/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip

--- a/templates/flutter-package/__brick__/example/android/settings.gradle
+++ b/templates/flutter-package/__brick__/example/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.12.1" apply false
-    id "org.jetbrains.kotlin.android" version "2.2.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 
 include ":app"

--- a/templates/flutter-package/__brick__/example/android/settings.gradle
+++ b/templates/flutter-package/__brick__/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.12.1" apply false
+    id "com.android.application" version "8.11.1" apply false
     id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 


### PR DESCRIPTION
- Bump Gradle wrapper to 8.14 in all Android projects - fixes the CI hard-fail (Flutter errors below Gradle 8.14.0).
- Kotlin/KGP → 2.2.20 (Flutter's minimum; stays within the Gradle 8.14 compatibility band).
- AGP → 8.11.1 (required upper bound for KGP 2.2.20, and Flutter's error floor).
- Unify compileSdk 36 / Java 17 across examples, canaries and the package template.
- Drop the manually-managed `kotlin-gradle-plugin` classpath from each native plugin's `buildscript` (KGP now comes from the Flutter/AGP toolchain), and modernize the jvmTarget config (`kotlinOptions` → `kotlin.compilerOptions`).
- Guard the `kotlin-android` apply so it is skipped only when the consumer has AGP built-in Kotlin enabled (AGP 9+ with `android.builtInKotlin=true`), where applying it is a hard error. On every currently-supported configuration (`flutter >=3.41.0`: AGP 8, or AGP 9 with `builtInKotlin=false`) the plugin is still applied — behavior-preserving today, and forward-compat insurance so already-released versions keep building when a future Flutter enables built-in Kotlin. Fully dropping the apply (built-in Kotlin migration, #7014) is left to a follow-up gated on a Flutter 3.47+ floor.

Verified with `flutter build apk --debug` on the in-repo example apps, and on fresh `flutter create` consumer apps built with Flutter 3.41.2 (AGP 8.11.1) and 3.44.6 (AGP 9.0.1, `builtInKotlin=false`); also confirmed the apply is correctly skipped when `builtInKotlin=true`.

### References:
 - AGP-Gradle-compi in Flutter: https://github.com/flutter/flutter/blob/6bfd8f4d381163edda287984adc2811e32d1c285/packages/flutter_tools/lib/src/android/gradle_utils.dart#L1125
 - KGP-Gradle-AGP: https://kotlinlang.org/docs/gradle-configure-project.html#apply-the-plugin
 - Built-in Kotlin migration (for #7014): https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors