### PR TITLE
chore(aft): Move git dependency off fork to pub.dev 2.3.2

### DIFF
--- a/packages/aft/pubspec.yaml
+++ b/packages/aft/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   code_builder: ^4.10.1
   collection: ^1.18.0
   file: ^7.0.1
-  git: ^2.2.0
+  git: ^2.3.2
   glob: ^2.1.0
   graphs: ^2.1.0
   io: ^1.0.4
@@ -50,10 +50,6 @@ dependency_overrides:
     path: ../aws_common
   aws_signature_v4:
     path: ../aws_signature_v4
-  git:
-    git:
-      url: https://github.com/tyllark/git
-      ref: feat/existing-worktree
   pub_server:
     path: ../test/pub_server
   smithy:

--- a/packages/aft/test/repo_test.dart
+++ b/packages/aft/test/repo_test.dart
@@ -1,0 +1,186 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+@TestOn('vm')
+library;
+
+import 'dart:io';
+
+import 'package:aft/src/config/config_loader.dart';
+import 'package:aft/src/git.dart';
+import 'package:aft/src/repo.dart';
+import 'package:checks/checks.dart';
+import 'package:git/git.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+const _rootPubspec = '''
+name: my_repo
+publish_to: none
+
+environment:
+  sdk: ^3.9.0
+''';
+
+const _packagePubspec = '''
+name: my_pkg
+version: 0.1.0
+
+environment:
+  sdk: ^3.9.0
+''';
+
+Future<String> _git(GitDir gitDir, List<String> args) async =>
+    ((await gitDir.runCommand(args)).stdout as String).trim();
+
+Future<Repo> _open(Directory workingDirectory) =>
+    Repo.open(AftConfigLoader(workingDirectory: workingDirectory).load());
+
+void main() {
+  group('Repo.open', () {
+    late Directory tempRoot;
+    late Directory mainCheckout;
+    late GitDir mainGit;
+    late String mainHead;
+
+    setUp(() async {
+      tempRoot = await Directory.systemTemp.createTemp('aft_repo_test_');
+      mainCheckout = Directory(p.join(tempRoot.path, 'main'))
+        ..createSync(recursive: true);
+      File(
+        p.join(mainCheckout.path, 'pubspec.yaml'),
+      ).writeAsStringSync(_rootPubspec);
+      Directory(
+        p.join(mainCheckout.path, 'packages', 'my_pkg'),
+      ).createSync(recursive: true);
+      File(
+        p.join(mainCheckout.path, 'packages', 'my_pkg', 'pubspec.yaml'),
+      ).writeAsStringSync(_packagePubspec);
+
+      mainGit = await GitDir.init(
+        mainCheckout.path,
+        allowContent: true,
+        initialBranch: 'main',
+      );
+      await mainGit.runCommand(['config', 'user.email', 'test@example.com']);
+      await mainGit.runCommand(['config', 'user.name', 'Test']);
+      await mainGit.runCommand(['add', '.']);
+      await mainGit.runCommand(['commit', '-m', 'chore: initial commit']);
+      mainHead = await _git(mainGit, ['rev-parse', 'HEAD']);
+    });
+
+    tearDown(() async {
+      if (tempRoot.existsSync()) {
+        await tempRoot.delete(recursive: true);
+      }
+    });
+
+    test('opens a standard checkout', () async {
+      final repo = await _open(mainCheckout);
+      check(
+        p.canonicalize(repo.rootDir.path),
+      ).equals(p.canonicalize(mainCheckout.path));
+      final (sha, _) = await repo.git.head;
+      check(sha).equals(mainHead);
+    });
+
+    test('opens from a nested package directory', () async {
+      final repo = await _open(
+        Directory(p.join(mainCheckout.path, 'packages', 'my_pkg')),
+      );
+      check(
+        p.canonicalize(repo.rootDir.path),
+      ).equals(p.canonicalize(mainCheckout.path));
+      final (sha, _) = await repo.git.head;
+      check(sha).equals(mainHead);
+    });
+
+    test('throws when the directory is not a git checkout', () async {
+      final notGit = Directory(p.join(tempRoot.path, 'not_git'))
+        ..createSync(recursive: true);
+      File(p.join(notGit.path, 'pubspec.yaml')).writeAsStringSync(_rootPubspec);
+      await check(_open(notGit)).throws<ProcessException>();
+    });
+
+    test('throws when the root pubspec is below the git root', () async {
+      final gitRoot = Directory(p.join(tempRoot.path, 'no_root_pubspec'))
+        ..createSync(recursive: true);
+      final nested = Directory(p.join(gitRoot.path, 'nested'))
+        ..createSync(recursive: true);
+      File(p.join(nested.path, 'pubspec.yaml')).writeAsStringSync(_rootPubspec);
+      final gitDir = await GitDir.init(gitRoot.path, allowContent: true);
+      await gitDir.runCommand(['config', 'user.email', 'test@example.com']);
+      await gitDir.runCommand(['config', 'user.name', 'Test']);
+      await gitDir.runCommand(['add', '.']);
+      await gitDir.runCommand(['commit', '-m', 'chore: initial commit']);
+      await check(_open(nested)).throws<ArgumentError>();
+    });
+
+    group('git worktree', () {
+      late Directory worktree;
+      late String worktreeHead;
+
+      setUp(() async {
+        worktree = Directory(p.join(tempRoot.path, 'worktree'));
+        await mainGit.runCommand([
+          'worktree',
+          'add',
+          '-b',
+          'release',
+          worktree.path,
+        ]);
+
+        // Add a worktree-only commit so the worktree `HEAD` is distinct from
+        // the main checkout `HEAD`.
+        File(
+          p.join(worktree.path, 'packages', 'my_pkg', 'lib.dart'),
+        ).writeAsStringSync('// worktree only\n');
+        final worktreeGit = await GitDir.fromExisting(worktree.path);
+        await worktreeGit.runCommand(['add', '.']);
+        await worktreeGit.runCommand(['commit', '-m', 'feat: worktree change']);
+        worktreeHead = await _git(worktreeGit, ['rev-parse', 'HEAD']);
+        check(worktreeHead).not((it) => it.equals(mainHead));
+      });
+
+      test('opens a worktree checkout', () async {
+        final repo = await _open(worktree);
+        check(
+          p.canonicalize(repo.rootDir.path),
+        ).equals(p.canonicalize(worktree.path));
+      });
+
+      test('opens from a nested package directory in a worktree', () async {
+        final repo = await _open(
+          Directory(p.join(worktree.path, 'packages', 'my_pkg')),
+        );
+        check(
+          p.canonicalize(repo.rootDir.path),
+        ).equals(p.canonicalize(worktree.path));
+      });
+
+      test('resolves HEAD from the worktree, not the main checkout', () async {
+        final repo = await _open(worktree);
+        final (sha, commit) = await repo.git.head;
+        check(sha).equals(worktreeHead);
+        check(commit.message.trim()).equals('feat: worktree change');
+        check(
+          await _git(repo.git, ['rev-parse', '--abbrev-ref', 'HEAD']),
+        ).equals('release');
+      });
+
+      test('lists worktree-only commits via revList', () async {
+        final repo = await _open(worktree);
+        final commits = await repo.git.revList(mainHead, worktreeHead).toList();
+        check(commits.map((c) => c.$1)).deepEquals([worktreeHead]);
+      });
+
+      test('diffs trees using worktree history', () async {
+        final repo = await _open(worktree);
+        final base = await repo.git.commitFromRevision(mainHead);
+        final head = await repo.git.commitFromRevision(worktreeHead);
+        final changed = await repo.git.diffTrees(base.treeSha, head.treeSha);
+        check(changed).contains('packages/my_pkg/lib.dart');
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Description

`packages/aft` pinned the `git` package to a personal fork via `dependency_overrides`:

```yaml
git:
  git:
    url: https://github.com/tyllark/git
    ref: feat/existing-worktree
```

That fork added a single commit on top of upstream `git` 2.2.1 so that
`GitDir.fromExisting` would accept a git worktree path instead of throwing.
`aft` needs this because `Repo.open` calls `GitDir.fromExisting` on the repo
root, so running any `aft` command from a worktree checkout failed.

Upstream fixed this in `git` 2.3.2 (kevmoo/git#87), which rewrote
`fromExisting` to use `git rev-parse --show-toplevel`. That resolves correctly
inside a worktree, so the fork is no longer needed.

This PR drops the override and bumps the constraint to `^2.3.2` so the fix is
guaranteed rather than merely allowed by `^2.2.0`.

### Upstream is also more correct than the fork

The fork returned a `GitDir` rooted at the *main* checkout and passed the
worktree via `--work-tree`. That made git resolve `HEAD` against the main
checkout, so `aft` running in a worktree read the wrong branch history.
Upstream 2.3.2 roots the `GitDir` at the worktree itself, so `HEAD`, the
current branch, and `rev-list` all reflect the worktree.

Verified behavior of `GitDir.fromExisting(<worktree>)`:

| `git` version | result | `HEAD` resolves to |
| --- | --- | --- |
| 2.2.1 (fork base) | throws `ArgumentError` | n/a |
| tyllark fork | ok, path = main checkout | main checkout branch (wrong) |
| 2.3.2 (pub.dev) | ok, path = worktree | worktree branch (correct) |

No API used by `aft` or `pub_server` changed between 2.2.1 and 2.3.2. The only
public signature change in that range is `Tag.parseCatFile`, which is unused
here.

## Tests

Adds `packages/aft/test/repo_test.dart` covering `Repo.open`, including the
worktree behavior that motivated the fork:

- opens a standard checkout, and from a nested package directory
- opens a worktree checkout, and from a nested package directory in a worktree
- resolves `HEAD` and the branch from the worktree, not the main checkout
- lists worktree-only commits via `revList`, and diffs trees across them
- throws when the directory is not a git checkout, and when the root pubspec
  sits below the git root

The tests were committed before the dependency change. Full `packages/aft`
suite, 122 tests:

| | fork (before) | 2.3.2 (after) |
| --- | --- | --- |
| failing | 8 | 7 |

The one difference is `resolves HEAD from the worktree, not the main checkout`,
which fails on the fork and passes on 2.3.2. The other 7 failures are identical
before and after and are pre-existing on `main` (6 `get-release-notes`
integration tests asserting empty stderr, which now picks up `Running build
hooks...`, plus a `package_selector_test.dart` load error from an ungenerated
`.g.dart`).

Also verified end to end by running the real CLI from a genuine worktree of
this repo: `aft list`, `aft locate-package`, and `aft version-bump --base-ref
main --head-ref HEAD` all succeeded, with `version-bump` correctly picking up a
worktree-only commit.
