### PR TITLE
fix(api): serialize TemporalDateTime in identifier for ModelQueries.get

### DIFF
--- a/infra-gen2/backends/api/api-multi-auth/amplify/data/resource.ts
+++ b/infra-gen2/backends/api/api-multi-auth/amplify/data/resource.ts
@@ -106,6 +106,14 @@ const schema = a.schema({
     .identifier(["intAsId", "fieldA", "fieldB"])
     .authorization((allow) => [allow.owner()]),
 
+  CpkTemporalPrimaryKey: a
+    .model({
+      hwid: a.string().required(),
+      sessionStart: a.datetime().required(),
+    })
+    .identifier(["hwid", "sessionStart"])
+    .authorization((allow) => [allow.authenticated()]),
+
   lowerCase: a
     .model({
       id: a.id().required(),

--- a/packages/api/amplify_api_dart/lib/src/graphql/factories/graphql_request_factory.dart
+++ b/packages/api/amplify_api_dart/lib/src/graphql/factories/graphql_request_factory.dart
@@ -148,7 +148,9 @@ class GraphQLRequestFactory {
           // codegen. Instead, just write the value to the document.
           final bLowerOutput = StringBuffer(_openParen);
           for (final field in modelIndex.fields) {
-            var value = modelIdentifier!.serializeAsMap()[field];
+            var value = _getSerializedValue(
+              modelIdentifier!.serializeAsMap()[field],
+            );
             if (value is String) {
               value = '"$value"';
             }
@@ -254,6 +256,14 @@ class GraphQLRequestFactory {
       'limit': limit,
       'nextToken': nextToken,
     };
+  }
+
+  Map<String, dynamic> buildVariablesForGetRequest({
+    required ModelIdentifier modelIdentifier,
+  }) {
+    return modelIdentifier.serializeAsMap().map(
+      (key, dynamic value) => MapEntry(key, _getSerializedValue(value)),
+    );
   }
 
   Map<String, dynamic> buildVariablesForMutationRequest({

--- a/packages/api/amplify_api_dart/lib/src/graphql/factories/model_queries_factory.dart
+++ b/packages/api/amplify_api_dart/lib/src/graphql/factories/model_queries_factory.dart
@@ -22,7 +22,8 @@ class ModelQueriesFactory {
     APIAuthorizationType? authorizationMode,
     Map<String, String>? headers,
   }) {
-    final variables = modelIdentifier.serializeAsMap();
+    final variables = GraphQLRequestFactory.instance
+        .buildVariablesForGetRequest(modelIdentifier: modelIdentifier);
     return GraphQLRequestFactory.instance.buildRequest<T>(
       modelType: modelType,
       modelIdentifier: modelIdentifier,

--- a/packages/api/amplify_api_dart/test/graphql_test.dart
+++ b/packages/api/amplify_api_dart/test/graphql_test.dart
@@ -225,6 +225,33 @@ void main() {
     });
 
     test(
+      'Query for a model with a TemporalDateTime in its custom identifier '
+      'serializes without throwing (regression test for #6298)',
+      () {
+        const hwid = '94B216FCC67F';
+        final sessionStart = TemporalDateTime.fromString(
+          '2025-03-28T23:07:34.000Z',
+        );
+        final serializedDate = sessionStart.toString();
+        final expectedDoc =
+            'query getCpkTemporalPrimaryKey { getCpkTemporalPrimaryKey(hwid: "$hwid", sessionStart: "$serializedDate") { hwid sessionStart } }';
+
+        final req = ModelQueries.get<CpkTemporalPrimaryKey>(
+          CpkTemporalPrimaryKey.classType,
+          CpkTemporalPrimaryKeyModelIdentifier(
+            hwid: hwid,
+            sessionStart: sessionStart,
+          ),
+        );
+
+        // document asserts
+        expect(req.document, expectedDoc);
+        // variables must be JSON-encodable
+        expect(() => json.encode(req.variables), returnsNormally);
+      },
+    );
+
+    test(
       'Mutation.create returns proper response.data for Models with custom types',
       () async {
         const expectedDoc = modelWithCustomTypeDocument;

--- a/packages/api/amplify_api_dart/test/graphql_test.dart
+++ b/packages/api/amplify_api_dart/test/graphql_test.dart
@@ -224,32 +224,29 @@ void main() {
       expect(res.errors, isEmpty);
     });
 
-    test(
-      'Query for a model with a TemporalDateTime in its custom identifier '
-      'serializes without throwing (regression test for #6298)',
-      () {
-        const hwid = '94B216FCC67F';
-        final sessionStart = TemporalDateTime.fromString(
-          '2025-03-28T23:07:34.000Z',
-        );
-        final serializedDate = sessionStart.toString();
-        final expectedDoc =
-            'query getCpkTemporalPrimaryKey { getCpkTemporalPrimaryKey(hwid: "$hwid", sessionStart: "$serializedDate") { hwid sessionStart } }';
+    test('Query for a model with a TemporalDateTime in its custom identifier '
+        'serializes without throwing (regression test for #6298)', () {
+      const hwid = '94B216FCC67F';
+      final sessionStart = TemporalDateTime.fromString(
+        '2025-03-28T23:07:34.000Z',
+      );
+      final serializedDate = sessionStart.toString();
+      final expectedDoc =
+          'query getCpkTemporalPrimaryKey { getCpkTemporalPrimaryKey(hwid: "$hwid", sessionStart: "$serializedDate") { hwid sessionStart } }';
 
-        final req = ModelQueries.get<CpkTemporalPrimaryKey>(
-          CpkTemporalPrimaryKey.classType,
-          CpkTemporalPrimaryKeyModelIdentifier(
-            hwid: hwid,
-            sessionStart: sessionStart,
-          ),
-        );
+      final req = ModelQueries.get<CpkTemporalPrimaryKey>(
+        CpkTemporalPrimaryKey.classType,
+        CpkTemporalPrimaryKeyModelIdentifier(
+          hwid: hwid,
+          sessionStart: sessionStart,
+        ),
+      );
 
-        // document asserts
-        expect(req.document, expectedDoc);
-        // variables must be JSON-encodable
-        expect(() => json.encode(req.variables), returnsNormally);
-      },
-    );
+      // document asserts
+      expect(req.document, expectedDoc);
+      // variables must be JSON-encodable
+      expect(() => json.encode(req.variables), returnsNormally);
+    });
 
     test(
       'Mutation.create returns proper response.data for Models with custom types',

--- a/packages/api/amplify_api_dart/test/test_models/CpkTemporalPrimaryKey.dart
+++ b/packages/api/amplify_api_dart/test/test_models/CpkTemporalPrimaryKey.dart
@@ -1,0 +1,287 @@
+/*
+* Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the "license" file accompanying this file. This file is distributed
+* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: public_member_api_docs, annotate_overrides, dead_code, dead_codepublic_member_api_docs, depend_on_referenced_packages, file_names, library_private_types_in_public_api, no_leading_underscores_for_library_prefixes, no_leading_underscores_for_local_identifiers, non_constant_identifier_names, null_check_on_nullable_type_parameter, override_on_non_overriding_member, prefer_adjacent_string_concatenation, prefer_const_constructors, prefer_if_null_operators, prefer_interpolation_to_compose_strings, slash_for_doc_comments, sort_child_properties_last, unnecessary_const, unnecessary_constructor_name, unnecessary_late, unnecessary_new, unnecessary_null_aware_assignments, unnecessary_nullable_for_final_variable_declarations, unnecessary_string_interpolations, use_build_context_synchronously
+
+import 'ModelProvider.dart';
+import 'package:amplify_core/amplify_core.dart' as amplify_core;
+
+/** This is a test model representing a type whose custom primary key includes a
+ * `TemporalDateTime` field. It mirrors a Gen2 schema such as:
+ *
+ * ```ts
+ * Metrics: a
+ *   .model({
+ *     hwid: a.string().required(),
+ *     sessionStart: a.datetime().required(),
+ *   })
+ *   .identifier(["hwid", "sessionStart"])
+ * ```
+ *
+ * Used to reproduce https://github.com/aws-amplify/amplify-flutter/issues/6298 where a
+ * `TemporalDateTime` in the identifier fails to serialize in `ModelQueries.get()`.
+ */
+class CpkTemporalPrimaryKey extends amplify_core.Model {
+  static const classType = const _CpkTemporalPrimaryKeyModelType();
+  final String? _hwid;
+  final amplify_core.TemporalDateTime? _sessionStart;
+
+  @override
+  getInstanceType() => classType;
+
+  @Deprecated(
+    '[getId] is being deprecated in favor of custom primary key feature. Use getter [modelIdentifier] to get model identifier.',
+  )
+  @override
+  String getId() => modelIdentifier.serializeAsString();
+
+  CpkTemporalPrimaryKeyModelIdentifier get modelIdentifier {
+    try {
+      return CpkTemporalPrimaryKeyModelIdentifier(
+        hwid: _hwid!,
+        sessionStart: _sessionStart!,
+      );
+    } catch (e) {
+      throw amplify_core.AmplifyCodeGenModelException(
+        amplify_core
+            .AmplifyExceptionMessages
+            .codeGenRequiredFieldForceCastExceptionMessage,
+        recoverySuggestion: amplify_core
+            .AmplifyExceptionMessages
+            .codeGenRequiredFieldForceCastRecoverySuggestion,
+        underlyingException: e.toString(),
+      );
+    }
+  }
+
+  String get hwid {
+    try {
+      return _hwid!;
+    } catch (e) {
+      throw amplify_core.AmplifyCodeGenModelException(
+        amplify_core
+            .AmplifyExceptionMessages
+            .codeGenRequiredFieldForceCastExceptionMessage,
+        recoverySuggestion: amplify_core
+            .AmplifyExceptionMessages
+            .codeGenRequiredFieldForceCastRecoverySuggestion,
+        underlyingException: e.toString(),
+      );
+    }
+  }
+
+  amplify_core.TemporalDateTime get sessionStart {
+    try {
+      return _sessionStart!;
+    } catch (e) {
+      throw amplify_core.AmplifyCodeGenModelException(
+        amplify_core
+            .AmplifyExceptionMessages
+            .codeGenRequiredFieldForceCastExceptionMessage,
+        recoverySuggestion: amplify_core
+            .AmplifyExceptionMessages
+            .codeGenRequiredFieldForceCastRecoverySuggestion,
+        underlyingException: e.toString(),
+      );
+    }
+  }
+
+  const CpkTemporalPrimaryKey._internal({
+    required hwid,
+    required sessionStart,
+  }) : _hwid = hwid,
+       _sessionStart = sessionStart;
+
+  factory CpkTemporalPrimaryKey({
+    required String hwid,
+    required amplify_core.TemporalDateTime sessionStart,
+  }) {
+    return CpkTemporalPrimaryKey._internal(
+      hwid: hwid,
+      sessionStart: sessionStart,
+    );
+  }
+
+  bool equals(Object other) {
+    return this == other;
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is CpkTemporalPrimaryKey &&
+        _hwid == other._hwid &&
+        _sessionStart == other._sessionStart;
+  }
+
+  @override
+  int get hashCode => toString().hashCode;
+
+  @override
+  String toString() {
+    var buffer = new StringBuffer();
+
+    buffer.write("CpkTemporalPrimaryKey {");
+    buffer.write("hwid=" + (_hwid != null ? _hwid! : "null") + ", ");
+    buffer.write(
+      "sessionStart=" +
+          (_sessionStart != null ? _sessionStart!.format() : "null"),
+    );
+    buffer.write("}");
+
+    return buffer.toString();
+  }
+
+  CpkTemporalPrimaryKey copyWith() {
+    return CpkTemporalPrimaryKey._internal(
+      hwid: hwid,
+      sessionStart: sessionStart,
+    );
+  }
+
+  CpkTemporalPrimaryKey copyWithModelFieldValues() {
+    return CpkTemporalPrimaryKey._internal(
+      hwid: hwid,
+      sessionStart: sessionStart,
+    );
+  }
+
+  CpkTemporalPrimaryKey.fromJson(Map<String, dynamic> json)
+    : _hwid = json['hwid'],
+      _sessionStart = json['sessionStart'] != null
+          ? amplify_core.TemporalDateTime.fromString(json['sessionStart'])
+          : null;
+
+  Map<String, dynamic> toJson() => {
+    'hwid': _hwid,
+    'sessionStart': _sessionStart?.format(),
+  };
+
+  Map<String, Object?> toMap() => {
+    'hwid': _hwid,
+    'sessionStart': _sessionStart,
+  };
+
+  static final amplify_core.QueryModelIdentifier<
+    CpkTemporalPrimaryKeyModelIdentifier
+  >
+  MODEL_IDENTIFIER =
+      amplify_core.QueryModelIdentifier<CpkTemporalPrimaryKeyModelIdentifier>();
+  static final HWID = amplify_core.QueryField(fieldName: "hwid");
+  static final SESSIONSTART = amplify_core.QueryField(fieldName: "sessionStart");
+  static var schema = amplify_core.Model.defineSchema(
+    define: (amplify_core.ModelSchemaDefinition modelSchemaDefinition) {
+      modelSchemaDefinition.name = "CpkTemporalPrimaryKey";
+      modelSchemaDefinition.pluralName = "CpkTemporalPrimaryKeys";
+
+      modelSchemaDefinition.indexes = [
+        amplify_core.ModelIndex(
+          fields: const ["hwid", "sessionStart"],
+          name: null,
+        ),
+      ];
+
+      modelSchemaDefinition.addField(
+        amplify_core.ModelFieldDefinition.field(
+          key: CpkTemporalPrimaryKey.HWID,
+          isRequired: true,
+          ofType: amplify_core.ModelFieldType(
+            amplify_core.ModelFieldTypeEnum.string,
+          ),
+        ),
+      );
+
+      modelSchemaDefinition.addField(
+        amplify_core.ModelFieldDefinition.field(
+          key: CpkTemporalPrimaryKey.SESSIONSTART,
+          isRequired: true,
+          ofType: amplify_core.ModelFieldType(
+            amplify_core.ModelFieldTypeEnum.dateTime,
+          ),
+        ),
+      );
+    },
+  );
+}
+
+class _CpkTemporalPrimaryKeyModelType
+    extends amplify_core.ModelType<CpkTemporalPrimaryKey> {
+  const _CpkTemporalPrimaryKeyModelType();
+
+  @override
+  CpkTemporalPrimaryKey fromJson(Map<String, dynamic> jsonData) {
+    return CpkTemporalPrimaryKey.fromJson(jsonData);
+  }
+
+  @override
+  String modelName() {
+    return 'CpkTemporalPrimaryKey';
+  }
+}
+
+/**
+ * This is an auto generated class representing the model identifier
+ * of [CpkTemporalPrimaryKey] in your schema.
+ */
+class CpkTemporalPrimaryKeyModelIdentifier
+    implements amplify_core.ModelIdentifier<CpkTemporalPrimaryKey> {
+  final String hwid;
+  final amplify_core.TemporalDateTime sessionStart;
+
+  /**
+   * Create an instance of CpkTemporalPrimaryKeyModelIdentifier using [hwid] the primary key.
+   * And [sessionStart] the sort key.
+   */
+  const CpkTemporalPrimaryKeyModelIdentifier({
+    required this.hwid,
+    required this.sessionStart,
+  });
+
+  @override
+  Map<String, dynamic> serializeAsMap() => (<String, dynamic>{
+    'hwid': hwid,
+    'sessionStart': sessionStart,
+  });
+
+  @override
+  List<Map<String, dynamic>> serializeAsList() => serializeAsMap().entries
+      .map((entry) => (<String, dynamic>{entry.key: entry.value}))
+      .toList();
+
+  @override
+  String serializeAsString() => serializeAsMap().values.join('#');
+
+  @override
+  String toString() =>
+      'CpkTemporalPrimaryKeyModelIdentifier(hwid: $hwid, sessionStart: $sessionStart)';
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+
+    return other is CpkTemporalPrimaryKeyModelIdentifier &&
+        hwid == other.hwid &&
+        sessionStart == other.sessionStart;
+  }
+
+  @override
+  int get hashCode => hwid.hashCode ^ sessionStart.hashCode;
+}

--- a/packages/api/amplify_api_dart/test/test_models/CpkTemporalPrimaryKey.dart
+++ b/packages/api/amplify_api_dart/test/test_models/CpkTemporalPrimaryKey.dart
@@ -1,21 +1,5 @@
-/*
-* Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License").
-* You may not use this file except in compliance with the License.
-* A copy of the License is located at
-*
-*  http://aws.amazon.com/apache2.0
-*
-* or in the "license" file accompanying this file. This file is distributed
-* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-* express or implied. See the License for the specific language governing
-* permissions and limitations under the License.
-*/
-
-// NOTE: This file is generated and may not follow lint rules defined in your app
-// Generated files can be excluded from analysis in analysis_options.yaml
-// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 // ignore_for_file: public_member_api_docs, annotate_overrides, dead_code, dead_codepublic_member_api_docs, depend_on_referenced_packages, file_names, library_private_types_in_public_api, no_leading_underscores_for_library_prefixes, no_leading_underscores_for_local_identifiers, non_constant_identifier_names, null_check_on_nullable_type_parameter, override_on_non_overriding_member, prefer_adjacent_string_concatenation, prefer_const_constructors, prefer_if_null_operators, prefer_interpolation_to_compose_strings, slash_for_doc_comments, sort_child_properties_last, unnecessary_const, unnecessary_constructor_name, unnecessary_late, unnecessary_new, unnecessary_null_aware_assignments, unnecessary_nullable_for_final_variable_declarations, unnecessary_string_interpolations, use_build_context_synchronously
 
@@ -102,11 +86,9 @@ class CpkTemporalPrimaryKey extends amplify_core.Model {
     }
   }
 
-  const CpkTemporalPrimaryKey._internal({
-    required hwid,
-    required sessionStart,
-  }) : _hwid = hwid,
-       _sessionStart = sessionStart;
+  const CpkTemporalPrimaryKey._internal({required hwid, required sessionStart})
+    : _hwid = hwid,
+      _sessionStart = sessionStart;
 
   factory CpkTemporalPrimaryKey({
     required String hwid,
@@ -184,7 +166,9 @@ class CpkTemporalPrimaryKey extends amplify_core.Model {
   MODEL_IDENTIFIER =
       amplify_core.QueryModelIdentifier<CpkTemporalPrimaryKeyModelIdentifier>();
   static final HWID = amplify_core.QueryField(fieldName: "hwid");
-  static final SESSIONSTART = amplify_core.QueryField(fieldName: "sessionStart");
+  static final SESSIONSTART = amplify_core.QueryField(
+    fieldName: "sessionStart",
+  );
   static var schema = amplify_core.Model.defineSchema(
     define: (amplify_core.ModelSchemaDefinition modelSchemaDefinition) {
       modelSchemaDefinition.name = "CpkTemporalPrimaryKey";
@@ -254,10 +238,8 @@ class CpkTemporalPrimaryKeyModelIdentifier
   });
 
   @override
-  Map<String, dynamic> serializeAsMap() => (<String, dynamic>{
-    'hwid': hwid,
-    'sessionStart': sessionStart,
-  });
+  Map<String, dynamic> serializeAsMap() =>
+      (<String, dynamic>{'hwid': hwid, 'sessionStart': sessionStart});
 
   @override
   List<Map<String, dynamic>> serializeAsList() => serializeAsMap().entries

--- a/packages/api/amplify_api_dart/test/test_models/ModelProvider.dart
+++ b/packages/api/amplify_api_dart/test/test_models/ModelProvider.dart
@@ -27,6 +27,7 @@ import 'CpkIntPrimaryKey.dart';
 import 'CpkOneToOneBidirectionalChildExplicitCD.dart';
 import 'CpkOneToOneBidirectionalChildImplicitCD.dart';
 import 'CpkOneToOneBidirectionalParentCD.dart';
+import 'CpkTemporalPrimaryKey.dart';
 import 'CustomOwnerField.dart';
 import 'ModelWithAppsyncScalarTypes.dart';
 import 'ModelWithCustomType.dart';
@@ -43,6 +44,7 @@ export 'CpkIntPrimaryKey.dart';
 export 'CpkOneToOneBidirectionalChildExplicitCD.dart';
 export 'CpkOneToOneBidirectionalChildImplicitCD.dart';
 export 'CpkOneToOneBidirectionalParentCD.dart';
+export 'CpkTemporalPrimaryKey.dart';
 export 'CustomOwnerField.dart';
 export 'CustomTypeWithAppsyncScalarTypes.dart';
 export 'EnumField.dart';
@@ -65,6 +67,7 @@ class ModelProvider implements amplify_core.ModelProviderInterface {
     CpkOneToOneBidirectionalChildExplicitCD.schema,
     CpkOneToOneBidirectionalChildImplicitCD.schema,
     CpkOneToOneBidirectionalParentCD.schema,
+    CpkTemporalPrimaryKey.schema,
     CustomOwnerField.schema,
     ModelWithAppsyncScalarTypes.schema,
     ModelWithCustomType.schema,


### PR DESCRIPTION
`ModelQueries.get()` throws `JsonUnsupportedObjectError` when an identifier has a
`TemporalDateTime` in it. The get path doesn't run identifier values through
`_getSerializedValue` like the list/filter path does, so the date never gets
stringified before JSON-encoding.

Re: #6298.

- Serialize `get` variables via `buildVariablesForGetRequest`.
- Serialize the composite-key `get` document values too (date comes out quoted).
- Add `CpkTemporalPrimaryKey` test model + regression test.
- Add matching `CpkTemporalPrimaryKey` model to the `api-multi-auth` gen2 backend.

`dart analyze` clean, tests red to green. Draft: live AppSync e2e still pending backend deploy + codegen.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
