### PR TITLE
fix(aft): Sync package_selector_test with repo

### DIFF
--- a/packages/aft/test/config/package_selector_test.dart
+++ b/packages/aft/test/config/package_selector_test.dart
@@ -32,6 +32,7 @@ void main() {
           nameSelector.allPaths(repoState),
           matchesPackagePaths([
             'packages/amplify/amplify_flutter/example',
+            'packages/amplify_connect_client/amplify_connect_client/example',
             'packages/amplify_datastore/example',
             'packages/amplify_native_legacy_wrapper/example',
             'packages/analytics/amplify_analytics_pinpoint/example',
@@ -129,6 +130,7 @@ void main() {
         matchesPackagePaths([
           'canaries',
           'packages/amplify/amplify_flutter/example',
+          'packages/amplify_connect_client/amplify_connect_client/example',
           'packages/kinesis/amplify_firehose/example',
           'packages/amplify_core/doc',
           'packages/amplify_datastore/example',


### PR DESCRIPTION
The hardcoded expected paths in `package_selector_test.dart` were missing the `amplify_connect_client` example, so both selector tests failed on main.