### PR TITLE
test(core): Multi-isolate spike evidence for Amplify configure (#5302)

### DIFF
--- a/packages/amplify/amplify_flutter/test/isolate_binary_messenger_test.dart
+++ b/packages/amplify/amplify_flutter/test/isolate_binary_messenger_test.dart
@@ -1,0 +1,207 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Spike evidence for https://github.com/aws-amplify/amplify-flutter/issues/5302
+// ("Support Amplify in multiple Dart Isolates").
+//
+// `packages/amplify_core/test/amplify_class_isolate_test.dart` shows that
+// Amplify's Dart state is already isolate-local, so a second isolate can build
+// its own `AmplifyClass` and configure it. This file covers the blocker that
+// remains for anything backed by a platform channel: an isolate started with a
+// bare `Isolate.spawn` has no `BinaryMessenger`, so every MethodChannel/Pigeon
+// call in it throws before a message is ever sent.
+//
+// Runs on the host under `flutter test` (no device needed). Completing an
+// actual round trip to native is device-gated and lives in
+// `packages/secure_storage/amplify_secure_storage/example/integration_test/background_isolate_messenger_test.dart`
+// -- `flutter_tester` refuses to service platform messages from a background
+// isolate ("Callbacks into the Dart VM are currently prohibited"), so it can
+// only be proven on a real engine.
+
+@TestOn('vm')
+library;
+
+import 'dart:async';
+import 'dart:isolate';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// A channel that intentionally has no implementation.
+///
+/// Which channel is used is irrelevant: acquiring the messenger fails before
+/// any message is encoded, which is exactly why this blocks every Amplify
+/// Pigeon channel equally.
+const _channel = MethodChannel('com.amazonaws.amplify/isolate_spike');
+
+/// What [probeMessengerInIsolate] observed, sent back over a [SendPort].
+///
+/// Only primitives are sent, so a failure is always reportable even when the
+/// thrown object itself is not sendable across isolates.
+typedef IsolateReport = Map<String, Object?>;
+
+/// Inspects the platform-channel plumbing available to the isolate this runs
+/// in, and reports it back over the [SendPort] in [message].
+///
+/// [message] also carries the root isolate's [RootIsolateToken], or `null` to
+/// leave the isolate in the state a bare `Isolate.spawn` produces, and whether
+/// to attempt a real [MethodChannel] invocation.
+Future<void> probeMessengerInIsolate(
+  (SendPort, RootIsolateToken?, bool) message,
+) async {
+  final (sendPort, rootIsolateToken, attemptInvoke) = message;
+  final report = <String, Object?>{
+    'debugName': Isolate.current.debugName,
+    'tokenProvided': rootIsolateToken != null,
+  };
+
+  // `null` here is what makes Flutter's channels resolve their messenger via
+  // `BackgroundIsolateBinaryMessenger.instance` instead of
+  // `ServicesBinding.instance.defaultBinaryMessenger`.
+  report['rootIsolateTokenIsNull'] = ServicesBinding.rootIsolateToken == null;
+
+  if (rootIsolateToken != null) {
+    try {
+      BackgroundIsolateBinaryMessenger.ensureInitialized(rootIsolateToken);
+      report['ensureInitializedError'] = null;
+    } on Object catch (e) {
+      report['ensureInitializedError'] = '${e.runtimeType}: $e';
+    }
+  }
+
+  try {
+    report['messenger'] = BackgroundIsolateBinaryMessenger.instance.runtimeType
+        .toString();
+  } on Object catch (e) {
+    report['messengerErrorType'] = e.runtimeType.toString();
+    report['messengerError'] = '$e';
+  }
+
+  try {
+    ServicesBinding.instance.defaultBinaryMessenger;
+    report['servicesBindingErrorType'] = null;
+  } on Object catch (e) {
+    report['servicesBindingErrorType'] = e.runtimeType.toString();
+  }
+
+  if (attemptInvoke) {
+    try {
+      await _channel.invokeMethod<void>('noop');
+      report['invokeErrorType'] = null;
+    } on Object catch (e) {
+      report['invokeErrorType'] = e.runtimeType.toString();
+      report['invokeError'] = '$e';
+    }
+  }
+
+  sendPort.send(report);
+}
+
+/// Spawns [probeMessengerInIsolate] and waits for its [IsolateReport].
+Future<IsolateReport> runInIsolate({
+  required String debugName,
+  required RootIsolateToken? rootIsolateToken,
+  bool attemptInvoke = false,
+}) async {
+  final receivePort = ReceivePort();
+  final errorPort = ReceivePort();
+  final result = Completer<IsolateReport>();
+
+  receivePort.listen((message) {
+    if (!result.isCompleted) {
+      result.complete((message as Map).cast<String, Object?>());
+    }
+  });
+  errorPort.listen((message) {
+    if (!result.isCompleted) {
+      result.completeError(StateError('Isolate $debugName errored: $message'));
+    }
+  });
+
+  final isolate = await Isolate.spawn(
+    probeMessengerInIsolate,
+    (receivePort.sendPort, rootIsolateToken, attemptInvoke),
+    onError: errorPort.sendPort,
+    errorsAreFatal: true,
+    debugName: debugName,
+  );
+  try {
+    return await result.future.timeout(const Duration(seconds: 30));
+  } finally {
+    isolate.kill(priority: Isolate.immediate);
+    receivePort.close();
+    errorPort.close();
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('background isolate binary messenger', () {
+    test('the root isolate has a token and a messenger', () {
+      expect(
+        RootIsolateToken.instance,
+        isNotNull,
+        reason: 'PR2 needs a token to hand to background isolates',
+      );
+      expect(ServicesBinding.rootIsolateToken, isNotNull);
+      expect(ServicesBinding.instance.defaultBinaryMessenger, isNotNull);
+    });
+
+    test('a spawned isolate has no messenger, so channel calls throw', () async {
+      final report = await runInIsolate(
+        debugName: 'no-messenger',
+        rootIsolateToken: null,
+        attemptInvoke: true,
+      );
+
+      expect(report['debugName'], 'no-messenger');
+      expect(report['tokenProvided'], isFalse);
+
+      // Flutter routes channel traffic in a background isolate through
+      // `BackgroundIsolateBinaryMessenger` precisely because this is null.
+      expect(report['rootIsolateTokenIsNull'], isTrue);
+
+      // The binding itself never exists in a spawned isolate.
+      expect(report['servicesBindingErrorType'], 'FlutterError');
+
+      expect(report['messengerErrorType'], 'StateError');
+      expect(
+        report['messengerError'],
+        contains('BackgroundIsolateBinaryMessenger.ensureInitialized'),
+      );
+
+      // This is the blocker for #5302: a real channel call fails, and it fails
+      // while looking up the messenger rather than at the host boundary.
+      expect(report['invokeErrorType'], 'StateError');
+      expect(
+        report['invokeError'],
+        contains('BackgroundIsolateBinaryMessenger.ensureInitialized'),
+        reason:
+            'If this stops throwing, Flutter now installs a messenger in '
+            'spawned isolates automatically and #5302 needs re-scoping.',
+      );
+    });
+
+    test(
+      'the root isolate token installs a messenger in a spawned isolate',
+      () async {
+        final report = await runInIsolate(
+          debugName: 'with-messenger',
+          rootIsolateToken: RootIsolateToken.instance,
+        );
+
+        expect(report['debugName'], 'with-messenger');
+        expect(report['tokenProvided'], isTrue);
+        expect(report['ensureInitializedError'], isNull);
+        expect(report['messengerErrorType'], isNull);
+        expect(report['messenger'], 'BackgroundIsolateBinaryMessenger');
+
+        // Only the messenger is installed. The binding is still absent, so
+        // anything reaching for `ServicesBinding.instance` directly stays broken
+        // -- worth knowing before PR2 picks an API shape.
+        expect(report['servicesBindingErrorType'], 'FlutterError');
+      },
+    );
+  });
+}

--- a/packages/amplify_core/test/amplify_class_isolate_test.dart
+++ b/packages/amplify_core/test/amplify_class_isolate_test.dart
@@ -1,0 +1,192 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+@TestOn('vm')
+library;
+
+import 'dart:async';
+import 'dart:isolate';
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:test/test.dart';
+
+const dummyConfiguration = '''{
+  "UserAgent": "aws-amplify-cli/2.0",
+  "Version": "1.0"
+}''';
+
+/// What [configureInIsolate] observed, sent back over a [SendPort].
+///
+/// Only primitives are sent so the message shape is identical on every VM
+/// target and does not depend on cross-isolate object sending.
+typedef IsolateReport = Map<String, Object?>;
+
+/// Configures a fresh [AmplifyClass] inside the isolate this runs in and
+/// reports what it observed back over [sendPort].
+Future<void> configureInIsolate(SendPort sendPort) async {
+  final report = <String, Object?>{'debugName': Isolate.current.debugName};
+  try {
+    report['instanceWasNullOnEntry'] = AmplifyClass.instance == null;
+    report['isConfiguredBefore'] = Amplify.isConfigured;
+    report['pluginCountBefore'] = Amplify.Analytics.plugins.length;
+
+    await Amplify.addPlugin(SuccessPlugin());
+    await Amplify.configure(dummyConfiguration);
+
+    report['isConfiguredAfter'] = Amplify.isConfigured;
+    report['pluginCountAfter'] = Amplify.Analytics.plugins.length;
+
+    try {
+      await Amplify.configure(dummyConfiguration);
+      report['secondConfigureError'] = null;
+    } on AmplifyAlreadyConfiguredException catch (e) {
+      report['secondConfigureError'] = e.runtimeTypeName;
+    }
+  } on Object catch (e, st) {
+    report['unexpectedError'] = '$e';
+    report['unexpectedStackTrace'] = '$st';
+  }
+  sendPort.send(report);
+}
+
+/// Spawns [configureInIsolate] in an isolate named [debugName] and waits for
+/// its [IsolateReport].
+///
+/// Uncaught errors in the child isolate are surfaced as an error on the
+/// returned future rather than hanging the test until timeout.
+Future<IsolateReport> runInIsolate(String debugName) async {
+  final receivePort = ReceivePort();
+  final errorPort = ReceivePort();
+  final result = Completer<IsolateReport>();
+
+  receivePort.listen((message) {
+    if (!result.isCompleted) {
+      result.complete((message as Map).cast<String, Object?>());
+    }
+  });
+  errorPort.listen((message) {
+    if (!result.isCompleted) {
+      result.completeError(StateError('Isolate $debugName errored: $message'));
+    }
+  });
+
+  final isolate = await Isolate.spawn(
+    configureInIsolate,
+    receivePort.sendPort,
+    onError: errorPort.sendPort,
+    errorsAreFatal: true,
+    debugName: debugName,
+  );
+  try {
+    return await result.future;
+  } finally {
+    isolate.kill(priority: Isolate.immediate);
+    receivePort.close();
+    errorPort.close();
+  }
+}
+
+void expectRanCleanlyIn(IsolateReport report, String debugName) {
+  expect(
+    report['unexpectedError'],
+    isNull,
+    reason:
+        'Child isolate failed:\n'
+        '${report['unexpectedError']}\n${report['unexpectedStackTrace']}',
+  );
+  expect(
+    report['debugName'],
+    debugName,
+    reason: 'Report should come from the spawned isolate, not the test isolate',
+  );
+}
+
+void main() {
+  group('Amplify', () {
+    group('isolates', () {
+      tearDown(() async {
+        await Amplify.reset();
+      });
+
+      test('configures independently in a spawned isolate', () async {
+        await Amplify.addPlugin(SuccessPlugin());
+        await Amplify.configure(dummyConfiguration);
+        expect(Amplify.isConfigured, isTrue);
+        expect(Amplify.Analytics.plugins, hasLength(1));
+        final parentInstance = AmplifyClass.instance;
+        expect(parentInstance, isNotNull);
+
+        final report = await runInIsolate('child');
+        expectRanCleanlyIn(report, 'child');
+
+        // (a) State is genuinely isolate-local: the child inherits neither the
+        // parent's `AmplifyClass.instance` nor its configured state, even
+        // though the parent configured before the child was spawned.
+        expect(report['instanceWasNullOnEntry'], isTrue);
+        expect(report['isConfiguredBefore'], isFalse);
+        expect(report['pluginCountBefore'], 0);
+
+        // (b) `configure` succeeds in the child.
+        expect(report['isConfiguredAfter'], isTrue);
+        expect(report['pluginCountAfter'], 1);
+
+        // (c) The child did not disturb the parent.
+        expect(Amplify.isConfigured, isTrue);
+        expect(Amplify.Analytics.plugins, hasLength(1));
+        expect(identical(AmplifyClass.instance, parentInstance), isTrue);
+        await expectLater(Amplify.asyncConfig, completes);
+      });
+
+      test('configures independently in multiple spawned isolates', () async {
+        final debugNames = ['child-1', 'child-2', 'child-3'];
+        final reports = await Future.wait(debugNames.map(runInIsolate));
+
+        for (final (index, report) in reports.indexed) {
+          expectRanCleanlyIn(report, debugNames[index]);
+          expect(report['instanceWasNullOnEntry'], isTrue);
+          expect(report['isConfiguredBefore'], isFalse);
+          expect(report['isConfiguredAfter'], isTrue);
+          expect(report['pluginCountAfter'], 1);
+        }
+
+        // The parent was never configured, and spawning isolates which
+        // configure did not configure it implicitly.
+        expect(Amplify.isConfigured, isFalse);
+        expect(Amplify.Analytics.plugins, isEmpty);
+      });
+
+      // (d) The `AmplifyAlreadyConfiguredException` guard is per-instance, and
+      // therefore per-isolate. It still fires for a second `configure` within
+      // the same isolate.
+      test('still throws when configured twice within one isolate', () async {
+        final report = await runInIsolate('child');
+        expectRanCleanlyIn(report, 'child');
+
+        expect(
+          report['secondConfigureError'],
+          'AmplifyAlreadyConfiguredException',
+        );
+      });
+
+      test('still throws when configured twice in the root isolate', () async {
+        await Amplify.addPlugin(SuccessPlugin());
+        await Amplify.configure(dummyConfiguration);
+
+        expect(
+          Amplify.configure(dummyConfiguration),
+          throwsA(isA<AmplifyAlreadyConfiguredException>()),
+        );
+      });
+    });
+  });
+}
+
+class SuccessPlugin extends AnalyticsPluginInterface {
+  @override
+  Future<void> configure({
+    AmplifyOutputs? config,
+    required AmplifyAuthProviderRepository authProviderRepo,
+  }) async {
+    return;
+  }
+}

--- a/packages/amplify_datastore/example/integration_test/isolate_native_singleton_test.dart
+++ b/packages/amplify_datastore/example/integration_test/isolate_native_singleton_test.dart
@@ -1,0 +1,219 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Device harness for https://github.com/aws-amplify/amplify-flutter/issues/5302
+// ("Support Amplify in multiple Dart Isolates").
+//
+// Registered in `main_test.dart`, so it runs on the existing `e2e_android` legs
+// (API 24 and 35), which provision this example's backend via
+// `needs-aws-config: true`. It is gated to Android, so the `e2e_ios` leg skips
+// it -- the native mapping asserted below was read from amplify-android and
+// nothing is claimed about amplify-swift.
+//
+// `packages/amplify_core/test/amplify_class_isolate_test.dart` shows Amplify's
+// Dart state is isolate-local, and
+// `packages/amplify/amplify_flutter/test/isolate_binary_messenger_test.dart`
+// shows a spawned isolate needs `BackgroundIsolateBinaryMessenger` before it can
+// talk to a platform channel. This file covers the third piece, which only a
+// real device can answer: the native SDK is a single process-wide instance, so a
+// second isolate with completely fresh Dart state still meets an
+// already-configured native Amplify.
+//
+// It asserts against the exception `AmplifyDataStore.configure` already swallows
+// today (see `packages/amplify_datastore/lib/amplify_datastore.dart`, the
+// `NativeAmplifyBridge.configure` call, and `hybrid_impl.dart`), raised by
+// `AmplifyDataStorePlugin.kt` as
+// `FlutterError("AmplifyAlreadyConfiguredException", ...)`.
+//
+// TESTING PLAN (for running it by hand; CI runs it automatically)
+// ---------------------------------------------------------------
+// Device:   Android emulator or device (CI uses API 24 and 35). An emulator
+//           needs KVM, so it cannot run on a host without nested
+//           virtualization.
+// Backend:  Requires `lib/amplifyconfiguration.dart`, same as every other test
+//           in this directory. Provision with
+//           `tool/provision_integration_test_resources.sh` or
+//           `tool/pull_test_backend.sh`.
+// Command:  cd packages/amplify_datastore/example
+//           flutter test integration_test/isolate_native_singleton_test.dart \
+//             -d emulator-5554
+// Expected: 3 tests pass. In particular `report['errorCode']` is
+//           `'AmplifyAlreadyConfiguredException'` while
+//           `report['dartStateWasEmpty']` is `true` in the same run -- fresh
+//           Dart state, already-configured native SDK. The report is printed to
+//           the test log so the observed values are visible in CI output.
+// Broken:   If `errorCode` is null, the native SDK accepted a second
+//           `configure()` and the process-wide-singleton premise of #5302 is
+//           wrong. If `errorCode` is `'channel-error'` or the test times out,
+//           `BackgroundIsolateBinaryMessenger.ensureInitialized` did not take
+//           effect and the messenger, not the native singleton, is what failed.
+//           If `dartStateWasEmpty` is false, `Isolate.spawn` started sharing
+//           statics and the whole plan needs revisiting.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:isolate';
+
+// ignore: implementation_imports
+import 'package:amplify_datastore/src/native_plugin.g.dart';
+import 'package:amplify_datastore_example/models/ModelProvider.dart';
+import 'package:amplify_flutter/amplify_flutter.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'utils/setup_utils.dart';
+
+/// What [configureNativeInIsolate] observed, sent back over a [SendPort].
+typedef IsolateReport = Map<String, Object?>;
+
+/// Asks native Amplify to configure itself a second time, from the isolate
+/// this runs in.
+///
+/// [message] carries the reply port, the root isolate's [RootIsolateToken], the
+/// Amplify version string and the raw configuration JSON. The version is passed
+/// in rather than read from `Amplify.version` so that this does not construct
+/// an [AmplifyClass] before recording whether one already existed.
+Future<void> configureNativeInIsolate(
+  (SendPort, RootIsolateToken, String, String) message,
+) async {
+  final (sendPort, rootIsolateToken, version, config) = message;
+  final report = <String, Object?>{
+    'debugName': Isolate.current.debugName,
+    'dartStateWasEmpty': AmplifyClass.instance == null,
+  };
+  try {
+    BackgroundIsolateBinaryMessenger.ensureInitialized(rootIsolateToken);
+    await NativeAmplifyBridge().configure(version, config);
+    report['errorCode'] = null;
+  } on PlatformException catch (e) {
+    report['errorCode'] = e.code;
+    report['errorMessage'] = e.message;
+  } on Object catch (e) {
+    report['errorType'] = e.runtimeType.toString();
+    report['error'] = '$e';
+  }
+  sendPort.send(report);
+}
+
+/// Spawns [configureNativeInIsolate] and waits for its [IsolateReport].
+Future<IsolateReport> runInIsolate({
+  required String debugName,
+  required RootIsolateToken rootIsolateToken,
+  required String version,
+  required String config,
+}) async {
+  final receivePort = ReceivePort();
+  final errorPort = ReceivePort();
+  final result = Completer<IsolateReport>();
+
+  receivePort.listen((message) {
+    if (!result.isCompleted) {
+      result.complete((message as Map).cast<String, Object?>());
+    }
+  });
+  errorPort.listen((message) {
+    if (!result.isCompleted) {
+      result.completeError(StateError('Isolate $debugName errored: $message'));
+    }
+  });
+
+  final isolate = await Isolate.spawn(
+    configureNativeInIsolate,
+    (receivePort.sendPort, rootIsolateToken, version, config),
+    onError: errorPort.sendPort,
+    errorsAreFatal: true,
+    debugName: debugName,
+  );
+  try {
+    return await result.future.timeout(const Duration(seconds: 60));
+  } finally {
+    isolate.kill(priority: Isolate.immediate);
+    receivePort.close();
+    errorPort.close();
+  }
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group(
+    'native Amplify is a process-wide singleton',
+    () {
+      late RootIsolateToken rootIsolateToken;
+      late String nativeConfig;
+
+      setUpAll(() async {
+        final token = RootIsolateToken.instance;
+        expect(token, isNotNull, reason: 'Must run on a real Flutter engine');
+        rootIsolateToken = token!;
+        await configureDataStore();
+        expect(Amplify.isConfigured, isTrue);
+        // Exactly what `AmplifyDataStore.configure` hands to
+        // `NativeAmplifyBridge.configure`: the parsed outputs re-encoded, not
+        // the raw Gen 1 `amplifyconfig` string. Using the same payload keeps
+        // this test on the real code path, so a thrown
+        // `AmplifyAlreadyConfiguredException` cannot be confused with a
+        // config-parsing failure.
+        // ignore: invalid_use_of_internal_member
+        nativeConfig = jsonEncode((await Amplify.asyncConfig).toJson());
+      });
+
+      testWidgets('a second native configure from the root isolate throws', (
+        _,
+      ) async {
+        await expectLater(
+          NativeAmplifyBridge().configure(Amplify.version, nativeConfig),
+          throwsA(
+            isA<PlatformException>().having(
+              (e) => e.code,
+              'code',
+              'AmplifyAlreadyConfiguredException',
+            ),
+          ),
+        );
+      });
+
+      testWidgets('a second native configure from a spawned isolate throws', (
+        _,
+      ) async {
+        final report = await runInIsolate(
+          debugName: 'native-configure',
+          rootIsolateToken: rootIsolateToken,
+          version: Amplify.version,
+          config: nativeConfig,
+        );
+
+        // Printed so the observed values show up in the CI log, not only on
+        // failure. This is the spike's primary evidence for #5302.
+        print('[issue-5302] native configure from spawned isolate: $report');
+
+        expect(report['debugName'], 'native-configure');
+        expect(
+          report['errorType'],
+          isNull,
+          reason:
+              'Unexpected non-PlatformException failure: '
+              '${report['errorType']}: ${report['error']}',
+        );
+
+        // The crux of #5302: the child's Dart state is empty, yet native Amplify
+        // is already configured, so the two layers must be handled separately.
+        expect(report['dartStateWasEmpty'], isTrue);
+        expect(report['errorCode'], 'AmplifyAlreadyConfiguredException');
+      });
+
+      testWidgets('the root isolate is undisturbed afterwards', (_) async {
+        expect(Amplify.isConfigured, isTrue);
+        expect(Amplify.DataStore.plugins, hasLength(1));
+        await expectLater(Amplify.DataStore.query(Blog.classType), completes);
+      });
+
+      // The verified native mapping to `AmplifyAlreadyConfiguredException` was
+      // read from amplify-android (`AmplifyDataStorePlugin.kt`). The iOS
+      // equivalent has not been checked, so this does not claim anything there.
+    },
+    skip: Platform.isAndroid ? null : 'Requires an Android device.',
+  );
+}

--- a/packages/amplify_datastore/example/integration_test/main_test.dart
+++ b/packages/amplify_datastore/example/integration_test/main_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
 import 'clear_test.dart' as clear_tests;
+import 'isolate_native_singleton_test.dart' as isolate_native_singleton_tests;
 import 'model_type_test.dart' as model_type_tests;
 import 'observe_query_test.dart' as observe_query_tests;
 import 'observe_test.dart' as observe_tests;
@@ -24,5 +25,8 @@ void main() async {
     observe_tests.main();
     observe_query_tests.main();
     clear_tests.main();
+    // Runs last: it asks native Amplify to configure a second time, which is a
+    // no-op that throws, so it must not sit in front of the functional suites.
+    isolate_native_singleton_tests.main();
   });
 }

--- a/packages/secure_storage/amplify_secure_storage/example/integration_test/background_isolate_messenger_test.dart
+++ b/packages/secure_storage/amplify_secure_storage/example/integration_test/background_isolate_messenger_test.dart
@@ -1,0 +1,242 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// DEVICE-GATED harness for https://github.com/aws-amplify/amplify-flutter/issues/5302
+// ("Support Amplify in multiple Dart Isolates"). NOT RUN IN CI, NOT YET RUN AT ALL.
+//
+// Covers the half of the messenger story that a real engine is required for.
+// `packages/amplify/amplify_flutter/test/isolate_binary_messenger_test.dart`
+// already proves on the host that a bare `Isolate.spawn`ed isolate cannot
+// acquire a `BinaryMessenger`, and that `RootIsolateToken` +
+// `BackgroundIsolateBinaryMessenger.ensureInitialized` installs one. What it
+// cannot prove is that a message then actually reaches native code:
+// `flutter_tester` refuses to service platform messages from a background
+// isolate ("Callbacks into the Dart VM are currently prohibited"). Only a real
+// device can close that gap, which is what this file does — against a real
+// Pigeon channel (`AmplifySecureStoragePigeon` -> EncryptedSharedPreferences).
+//
+// Deliberately NOT registered in `main_test.dart`: this example also has web,
+// wasm, linux and windows E2E legs, and `dart:io`/`dart:isolate` do not compile
+// for web. Registering it would break those legs.
+//
+// TESTING PLAN
+// ------------
+// Device:   Android emulator or physical device, any API level the example
+//           supports (CI's e2e_android legs use API 24 and 35). An emulator
+//           needs KVM, so it cannot run on a host without nested
+//           virtualization.
+// Backend:  None. `amplify_secure_storage` is purely local, and this file never
+//           calls `Amplify.configure`.
+// Steps:    1. Boot a device, confirm `flutter devices` lists it.
+//           2. cd packages/secure_storage/amplify_secure_storage/example
+//           3. flutter test integration_test/background_isolate_messenger_test.dart \
+//                -d emulator-5554
+// Expected: 4 tests pass, in this order of meaning —
+//           (1) the root isolate round-trips a value through the Pigeon channel;
+//           (2) a spawned isolate given NO token fails, with `report['error']`
+//               non-null and `report['readBack']` null;
+//           (3) the same isolate given `RootIsolateToken.instance` succeeds and
+//               `report['readBack'] == _value`;
+//           (4) the value written from the isolate is readable by the root,
+//               i.e. native storage is process-wide.
+// Broken:   Test (2) passing means Flutter now installs a messenger in spawned
+//           isolates automatically and #5302 needs re-scoping. Test (3) failing
+//           with a `PlatformException(code: 'channel-error')`, a
+//           `MissingPluginException`, or a 30s timeout means
+//           `ensureInitialized` did not actually wire the isolate to the engine
+//           — that is the interesting failure, and it would invalidate the
+//           token-passing design PR2 builds on. A `StateError` mentioning
+//           `BackgroundIsolateBinaryMessenger.ensureInitialized` in test (3)
+//           means the token was null/not applied.
+
+import 'dart:async';
+import 'dart:io';
+import 'dart:isolate';
+
+import 'package:amplify_secure_storage/amplify_secure_storage.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+const _namespace = 'com.amplify.isolateSpike';
+const _key = 'issue-5302';
+const _value = 'written-from-a-background-isolate';
+
+/// What [readWriteInIsolate] observed, sent back over a [SendPort].
+///
+/// Only primitives are sent so a failure in the child isolate is always
+/// reportable, even when the thrown object itself is not sendable.
+typedef IsolateReport = Map<String, Object?>;
+
+/// Performs a real Pigeon round trip from the isolate this runs in.
+///
+/// When [message] carries a [RootIsolateToken], the background isolate's
+/// binary messenger is installed first; otherwise the Pigeon call is made with
+/// no messenger at all, which is the state a bare `Isolate.spawn` leaves the
+/// isolate in.
+Future<void> readWriteInIsolate((SendPort, RootIsolateToken?) message) async {
+  final (sendPort, rootIsolateToken) = message;
+  final report = <String, Object?>{
+    'debugName': Isolate.current.debugName,
+    'messengerInitialized': rootIsolateToken != null,
+  };
+  try {
+    if (rootIsolateToken != null) {
+      BackgroundIsolateBinaryMessenger.ensureInitialized(rootIsolateToken);
+    }
+    // ignore: invalid_use_of_internal_member
+    final storage = AmplifySecureStorage(
+      config: AmplifySecureStorageConfig.byNamespace(namespace: _namespace),
+    );
+    await storage.write(key: _key, value: _value);
+    report['readBack'] = await storage.read(key: _key);
+  } on Object catch (e) {
+    report['errorType'] = e.runtimeType.toString();
+    report['error'] = '$e';
+  }
+  sendPort.send(report);
+}
+
+/// Spawns [readWriteInIsolate] and waits for its [IsolateReport].
+Future<IsolateReport> runInIsolate({
+  required String debugName,
+  required RootIsolateToken? rootIsolateToken,
+}) async {
+  final receivePort = ReceivePort();
+  final errorPort = ReceivePort();
+  final result = Completer<IsolateReport>();
+
+  receivePort.listen((message) {
+    if (!result.isCompleted) {
+      result.complete((message as Map).cast<String, Object?>());
+    }
+  });
+  errorPort.listen((message) {
+    if (!result.isCompleted) {
+      result.completeError(StateError('Isolate $debugName errored: $message'));
+    }
+  });
+
+  final isolate = await Isolate.spawn(
+    readWriteInIsolate,
+    (receivePort.sendPort, rootIsolateToken),
+    onError: errorPort.sendPort,
+    errorsAreFatal: true,
+    debugName: debugName,
+  );
+  try {
+    return await result.future.timeout(const Duration(seconds: 30));
+  } finally {
+    isolate.kill(priority: Isolate.immediate);
+    receivePort.close();
+    errorPort.close();
+  }
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group(
+    'BackgroundIsolateBinaryMessenger',
+    () {
+      late RootIsolateToken rootIsolateToken;
+
+      setUpAll(() {
+        final token = RootIsolateToken.instance;
+        expect(
+          token,
+          isNotNull,
+          reason: 'Test must run on a real Flutter engine, not the Dart VM',
+        );
+        rootIsolateToken = token!;
+      });
+
+      tearDown(() async {
+        // ignore: invalid_use_of_internal_member
+        final storage = AmplifySecureStorage(
+          config: AmplifySecureStorageConfig.byNamespace(namespace: _namespace),
+        );
+        await storage.delete(key: _key);
+      });
+
+      testWidgets('the root isolate can reach the Pigeon channel', (_) async {
+        // ignore: invalid_use_of_internal_member
+        final storage = AmplifySecureStorage(
+          config: AmplifySecureStorageConfig.byNamespace(namespace: _namespace),
+        );
+        await storage.write(key: _key, value: _value);
+
+        expect(await storage.read(key: _key), _value);
+      });
+
+      testWidgets('a spawned isolate cannot, without the root isolate token', (
+        _,
+      ) async {
+        final report = await runInIsolate(
+          debugName: 'no-messenger',
+          rootIsolateToken: null,
+        );
+
+        expect(report['debugName'], 'no-messenger');
+        expect(report['messengerInitialized'], isFalse);
+        expect(
+          report['error'],
+          isNotNull,
+          reason:
+              'A Pigeon call with no BinaryMessenger must fail. If this passes, '
+              'Flutter now auto-installs a messenger in spawned isolates and '
+              'issue #5302 needs re-scoping.',
+        );
+        expect(report['readBack'], isNull);
+      });
+
+      testWidgets('a spawned isolate can, once given the root isolate token', (
+        _,
+      ) async {
+        final report = await runInIsolate(
+          debugName: 'with-messenger',
+          rootIsolateToken: rootIsolateToken,
+        );
+
+        expect(report['debugName'], 'with-messenger');
+        expect(report['messengerInitialized'], isTrue);
+        expect(
+          report['error'],
+          isNull,
+          reason:
+              'Pigeon call failed in the background isolate: '
+              '${report['errorType']}: ${report['error']}',
+        );
+        expect(report['readBack'], _value);
+      });
+
+      testWidgets('the value written in the isolate is visible to the root', (
+        _,
+      ) async {
+        await runInIsolate(
+          debugName: 'with-messenger',
+          rootIsolateToken: rootIsolateToken,
+        );
+
+        // ignore: invalid_use_of_internal_member
+        final storage = AmplifySecureStorage(
+          config: AmplifySecureStorageConfig.byNamespace(namespace: _namespace),
+        );
+        expect(
+          await storage.read(key: _key),
+          _value,
+          reason:
+              'Native storage is process-wide, so a background isolate writes '
+              'into the same EncryptedSharedPreferences file as the root isolate',
+        );
+      });
+      // `AmplifySecureStoragePigeon` only exists on Android; every other platform
+      // reaches secure storage over FFI or a worker isolate, so it cannot prove
+      // anything about the binary messenger.
+    },
+    skip: Platform.isAndroid
+        ? null
+        : 'Requires an Android device: the secure '
+              'storage Pigeon channel is Android-only.',
+  );
+}


### PR DESCRIPTION
- Spike for #5302 (1st of a stacked series). Test-only — no production code touched.
- **Proven:** Amplify's Dart state is already isolate-local — a spawned isolate inherits nothing and completes `configure()` on its own, without disturbing the parent. The per-instance `AmplifyAlreadyConfiguredException` guard is unchanged. → `packages/amplify_core/test/amplify_class_isolate_test.dart`
- **Proven:** a bare `Isolate.spawn`ed isolate has no `BinaryMessenger`, so platform-channel calls throw; `RootIsolateToken` + `BackgroundIsolateBinaryMessenger.ensureInitialized` installs one (the binding still does not exist). → `packages/amplify/amplify_flutter/test/isolate_binary_messenger_test.dart` (first tests in this package, so `flutter test` now runs there)
- **Proven on device:** the native SDK is a process-wide singleton — a spawned isolate with empty Dart state still gets `AmplifyAlreadyConfiguredException` back from Kotlin (`dartStateWasEmpty: true` + `errorCode: AmplifyAlreadyConfiguredException` in one run). Runs and passes on the existing `e2e_android` legs (API 24 + 35), skipped on `e2e_ios`. → `packages/amplify_datastore/example/integration_test/isolate_native_singleton_test.dart`. The secure-storage Pigeon harness stays device-gated with a testing plan (that example has web/wasm legs; `dart:io`/`dart:isolate` do not compile for web).