### PR TITLE
chore(core): Format `doc/lib/auth.dart` for the Dart 3.13 formatter

### DIFF
--- a/packages/amplify_core/doc/lib/auth.dart
+++ b/packages/amplify_core/doc/lib/auth.dart
@@ -7,6 +7,7 @@ library;
 // #docregion imports
 import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
 import 'package:amplify_flutter/amplify_flutter.dart';
+
 // #enddocregion imports
 
 const username = '';


### PR DESCRIPTION
- Formats `packages/amplify_core/doc/lib/auth.dart` — unblocks `amplify_core`'s Check Formatting step, which fails on the stable leg now that stable is Dart 3.13.0. Formatting only, no behavior change.
- The formatter adds a blank line before `// #enddocregion imports`; the rendered excerpt in `amplify_auth_category.dart` is unchanged (`code_excerpt_updater` output is byte-identical before/after).