### PR TITLE
feat: Add isolate bootstrap helper for Amplify platform channels (#5302)

### DIFF
--- a/packages/amplify/amplify_flutter/lib/src/amplify_isolate.dart
+++ b/packages/amplify/amplify_flutter/lib/src/amplify_isolate.dart
@@ -1,0 +1,90 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+/// {@template amplify_flutter.amplify_root_isolate_token}
+/// The root isolate's token, to be passed to a secondary isolate for
+/// [ensureAmplifyIsolateInitialized].
+///
+/// This is `null` when there is no root isolate to bootstrap from: on the web,
+/// where isolates do not exist, and in a plain Dart VM process with no Flutter
+/// engine. It is also `null` when read from a secondary isolate, so it must be
+/// read on the root isolate and sent across.
+/// {@endtemplate}
+@internal
+RootIsolateToken? get amplifyRootIsolateToken {
+  // On the web `RootIsolateToken.instance` throws `UnsupportedError: Root
+  // isolate not identifiable on web.` rather than returning null, so web has to
+  // be short-circuited to keep this getter safe to read anywhere.
+  if (kIsWeb) return null;
+  return RootIsolateToken.instance;
+}
+
+/// {@template amplify_flutter.amplify_isolate_is_initialized}
+/// Whether the current isolate can reach Amplify's platform channels.
+///
+/// True on the root isolate, and on a secondary isolate once
+/// [ensureAmplifyIsolateInitialized] has run. Mirrors how Flutter itself
+/// resolves the messenger for a channel.
+/// {@endtemplate}
+@internal
+bool get amplifyIsolateIsInitialized {
+  // The web has no isolates, so channels are always reachable from its single
+  // execution context.
+  if (kIsWeb) return true;
+  // A non-null token means this is the root isolate, which resolves channels
+  // through `ServicesBinding` rather than a background messenger.
+  if (ServicesBinding.rootIsolateToken != null) return true;
+  try {
+    BackgroundIsolateBinaryMessenger.instance;
+    return true;
+  } on StateError {
+    return false;
+  }
+}
+
+/// {@template amplify_flutter.ensure_amplify_isolate_initialized}
+/// Makes Amplify's platform channels usable from the current isolate, using the
+/// root isolate's [token].
+///
+/// Amplify's Dart state is already isolate-local, so a secondary isolate builds
+/// its own `Amplify` instance and configures it independently of the root
+/// isolate. What a secondary isolate does *not* inherit is a [BinaryMessenger],
+/// so every plugin backed by a platform channel fails there — with a
+/// [StateError] raised while looking up the messenger, before a message is ever
+/// sent. Calling this repairs that.
+///
+/// Read [amplifyRootIsolateToken] on the root isolate, pass it to the secondary
+/// isolate, and call this there before using Amplify:
+///
+/// ```dart
+/// final token = amplifyRootIsolateToken!;
+/// await Isolate.spawn(_worker, token);
+///
+/// Future<void> _worker(RootIsolateToken token) async {
+///   ensureAmplifyIsolateInitialized(token);
+///   // Platform channels now work in this isolate.
+/// }
+/// ```
+///
+/// It is safe to call more than once, and it is a no-op on the root isolate —
+/// registering a background messenger there would replace the root isolate's
+/// platform message handler.
+///
+/// This only restores the messenger. [ServicesBinding.instance] is still
+/// unavailable in a secondary isolate, so code reaching for the binding
+/// directly continues to fail. Note also that the native Amplify SDKs are a
+/// single instance per process: configuring again from a secondary isolate
+/// reaches an already-configured native SDK, which reports
+/// `AmplifyAlreadyConfiguredException`.
+///
+/// There is nothing to call this with on the web, where
+/// [amplifyRootIsolateToken] is always `null`.
+/// {@endtemplate}
+@internal
+void ensureAmplifyIsolateInitialized(RootIsolateToken token) {
+  if (ServicesBinding.rootIsolateToken != null) return;
+  BackgroundIsolateBinaryMessenger.ensureInitialized(token);
+}

--- a/packages/amplify/amplify_flutter/test/isolate_bootstrap_test.dart
+++ b/packages/amplify/amplify_flutter/test/isolate_bootstrap_test.dart
@@ -1,0 +1,169 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+@TestOn('vm')
+library;
+
+import 'dart:async';
+import 'dart:isolate';
+
+import 'package:amplify_flutter/src/amplify_isolate.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// What [probeIsolate] observed, sent back over a [SendPort].
+///
+/// Only primitives are sent, so a failure is always reportable even when the
+/// thrown object itself is not sendable across isolates.
+typedef IsolateReport = Map<String, Object?>;
+
+/// Exercises the bootstrap helper from the isolate this runs in.
+///
+/// [message] carries the reply port, the root isolate's token or `null` to skip
+/// bootstrapping, and whether to call the helper a second time.
+Future<void> probeIsolate((SendPort, RootIsolateToken?, bool) message) async {
+  final (sendPort, token, callTwice) = message;
+  final report = <String, Object?>{
+    'debugName': Isolate.current.debugName,
+    'rootTokenIsNullHere': amplifyRootIsolateToken == null,
+    'initializedBefore': amplifyIsolateIsInitialized,
+  };
+  try {
+    if (token != null) {
+      ensureAmplifyIsolateInitialized(token);
+      if (callTwice) ensureAmplifyIsolateInitialized(token);
+    }
+    report['error'] = null;
+  } on Object catch (e) {
+    report['errorType'] = e.runtimeType.toString();
+    report['error'] = '$e';
+  }
+  report['initializedAfter'] = amplifyIsolateIsInitialized;
+  try {
+    report['messengerType'] = BackgroundIsolateBinaryMessenger
+        .instance
+        .runtimeType
+        .toString();
+  } on StateError {
+    report['messengerType'] = null;
+  }
+  sendPort.send(report);
+}
+
+/// Spawns [probeIsolate] and waits for its [IsolateReport].
+Future<IsolateReport> runInIsolate({
+  required String debugName,
+  required RootIsolateToken? token,
+  bool callTwice = false,
+}) async {
+  final receivePort = ReceivePort();
+  final errorPort = ReceivePort();
+  final result = Completer<IsolateReport>();
+
+  receivePort.listen((message) {
+    if (!result.isCompleted) {
+      result.complete((message as Map).cast<String, Object?>());
+    }
+  });
+  errorPort.listen((message) {
+    if (!result.isCompleted) {
+      result.completeError(StateError('Isolate $debugName errored: $message'));
+    }
+  });
+
+  final isolate = await Isolate.spawn(
+    probeIsolate,
+    (receivePort.sendPort, token, callTwice),
+    onError: errorPort.sendPort,
+    errorsAreFatal: true,
+    debugName: debugName,
+  );
+  try {
+    return await result.future.timeout(const Duration(seconds: 30));
+  } finally {
+    isolate.kill(priority: Isolate.immediate);
+    receivePort.close();
+    errorPort.close();
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('amplifyRootIsolateToken', () {
+    test('is available on the root isolate', () {
+      expect(amplifyRootIsolateToken, isNotNull);
+      expect(amplifyRootIsolateToken, same(RootIsolateToken.instance));
+    });
+
+    test('is null in a spawned isolate, so it must be sent across', () async {
+      final report = await runInIsolate(debugName: 'no-token', token: null);
+
+      expect(report['debugName'], 'no-token');
+      expect(report['rootTokenIsNullHere'], isTrue);
+    });
+  });
+
+  group('amplifyIsolateIsInitialized', () {
+    test('is true on the root isolate', () {
+      expect(amplifyIsolateIsInitialized, isTrue);
+    });
+
+    test('is false in a spawned isolate that was not bootstrapped', () async {
+      final report = await runInIsolate(debugName: 'no-token', token: null);
+
+      expect(report['initializedBefore'], isFalse);
+      expect(report['initializedAfter'], isFalse);
+      expect(report['messengerType'], isNull);
+    });
+  });
+
+  group('ensureAmplifyIsolateInitialized', () {
+    test('makes platform channels reachable in a spawned isolate', () async {
+      final report = await runInIsolate(
+        debugName: 'bootstrapped',
+        token: RootIsolateToken.instance,
+      );
+
+      expect(
+        report['error'],
+        isNull,
+        reason: 'Bootstrap failed: ${report['errorType']}: ${report['error']}',
+      );
+      expect(report['initializedBefore'], isFalse);
+      expect(report['initializedAfter'], isTrue);
+      expect(report['messengerType'], 'BackgroundIsolateBinaryMessenger');
+    });
+
+    test('is idempotent', () async {
+      final report = await runInIsolate(
+        debugName: 'bootstrapped-twice',
+        token: RootIsolateToken.instance,
+        callTwice: true,
+      );
+
+      expect(
+        report['error'],
+        isNull,
+        reason: 'Second call threw: ${report['errorType']}: ${report['error']}',
+      );
+      expect(report['initializedAfter'], isTrue);
+    });
+
+    test('is a no-op on the root isolate', () {
+      // Registering a background messenger on the root isolate would replace
+      // its platform message handler, so the helper must refuse to do it.
+      final before = ServicesBinding.instance.defaultBinaryMessenger;
+
+      ensureAmplifyIsolateInitialized(RootIsolateToken.instance!);
+
+      expect(ServicesBinding.instance.defaultBinaryMessenger, same(before));
+      expect(amplifyIsolateIsInitialized, isTrue);
+      // The root isolate never gets a background messenger installed.
+      expect(
+        () => BackgroundIsolateBinaryMessenger.instance,
+        throwsA(isA<StateError>()),
+      );
+    });
+  });
+}

--- a/packages/amplify/amplify_flutter/test/isolate_bootstrap_web_test.dart
+++ b/packages/amplify/amplify_flutter/test/isolate_bootstrap_web_test.dart
@@ -1,0 +1,42 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Guards web compatibility of the isolate bootstrap helper. `amplify_flutter`
+// declares web support and is compiled for web by downstream packages, so these
+// symbols must compile there and must not blow up when read.
+//
+// This is not a theoretical concern: on the web `RootIsolateToken.instance`
+// throws `UnsupportedError: Root isolate not identifiable on web.` instead of
+// returning null, so a naive getter would be a landmine for every web caller.
+//
+// `amplify_flutter`'s CI runs `flutter test` on the VM only, so this file is not
+// exercised there. Run it by hand:
+//
+//     cd packages/amplify/amplify_flutter
+//     flutter test test/isolate_bootstrap_web_test.dart --platform chrome
+
+@TestOn('browser')
+library;
+
+import 'package:amplify_flutter/src/amplify_isolate.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('on the web', () {
+    test('reading the root isolate token yields null instead of throwing', () {
+      expect(amplifyRootIsolateToken, isNull);
+    });
+
+    test('platform channels are always reachable', () {
+      expect(amplifyIsolateIsInitialized, isTrue);
+    });
+
+    // There is deliberately no test for `ensureAmplifyIsolateInitialized` on
+    // the web: it takes a non-nullable `RootIsolateToken`, `RootIsolateToken`
+    // has no public constructor, and `amplifyRootIsolateToken` is always null
+    // here -- so the call is unreachable by construction rather than by a
+    // runtime guard.
+  });
+}


### PR DESCRIPTION
PR2 of the #5302 stack, on top of #7266. Purely additive — no existing file modified, not exported from the barrel, so single-isolate behaviour is unchanged.

- Adds `ensureAmplifyIsolateInitialized(token)` / `amplifyRootIsolateToken` / `amplifyIsolateIsInitialized` in `packages/amplify/amplify_flutter/lib/src/amplify_isolate.dart`. Home is `amplify_flutter`, not `amplify_core`: `RootIsolateToken` and `BackgroundIsolateBinaryMessenger` are Flutter types and `amplify_core` is deliberately Flutter-free.
- **`@internal` for now** — promoting later is additive and non-breaking, while shipping it publicly now would commit us under semver before multi-isolate works end to end (the native SDK still rejects a second `configure()`). Recommend promoting in the PR that lands the broker + docs + example.
- Two sharp edges the helper absorbs: it is a **no-op on the root isolate** (registering a background messenger there would replace the root's platform message handler), and `amplifyRootIsolateToken` returns `null` on web because `RootIsolateToken.instance` *throws* `UnsupportedError` there rather than returning null.
- 9 tests, 7 of them running in CI on the VM (root/secondary behaviour, idempotency, root no-op); 2 web tests run by hand with `--platform chrome` since this package's CI is VM-only. Top-level functions rather than `AmplifyIsolate.ensureInitialized` because `amplify_lints` bans `avoid_classes_with_only_static_members`.