### PR TITLE
feat(datastore): Refuse configure from a secondary isolate (#5302)

### DIFF
--- a/packages/amplify_datastore/lib/amplify_datastore.dart
+++ b/packages/amplify_datastore/lib/amplify_datastore.dart
@@ -7,6 +7,7 @@ import 'dart:convert';
 import 'package:amplify_core/amplify_core.dart';
 import 'package:amplify_datastore/src/amplify_datastore_stream_controller.dart';
 import 'package:amplify_datastore/src/datastore_plugin_options.dart';
+import 'package:amplify_datastore/src/isolate_context.dart';
 import 'package:amplify_datastore/src/method_channel_datastore.dart';
 import 'package:amplify_datastore/src/native_plugin.g.dart';
 import 'package:amplify_datastore/src/utils/native_api_helpers.dart';
@@ -53,6 +54,22 @@ class AmplifyDataStore extends DataStorePluginInterface
     AmplifyOutputs? config,
     required AmplifyAuthProviderRepository authProviderRepo,
   }) async {
+    // Checked before the config, because being on the wrong isolate cannot be
+    // fixed by supplying a config. Native Amplify is a single instance per
+    // process, so a secondary isolate would either fail on the platform channel
+    // or quietly attach to the root isolate's already-configured native SDK.
+    if (!amplifyIsInRootIsolate) {
+      throw PluginError(
+        'AmplifyDataStore cannot be configured from a secondary isolate. The '
+        'native DataStore SDK is a single instance per process and belongs to '
+        'the root isolate.',
+        recoverySuggestion:
+            'Add AmplifyDataStore and call Amplify.configure on the root '
+            'isolate, and use the DataStore category from there. Categories '
+            'which run entirely in Dart can still be configured in a secondary '
+            'isolate.',
+      );
+    }
     if (config == null) {
       throw ConfigurationError('No Amplify config provided');
     }

--- a/packages/amplify_datastore/lib/src/isolate_context.dart
+++ b/packages/amplify_datastore/lib/src/isolate_context.dart
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+/// {@template amplify_datastore.amplify_is_in_root_isolate}
+/// Whether the current isolate is a root isolate, meaning it owns a Flutter
+/// engine and may therefore drive the process-wide native Amplify SDK.
+///
+/// True on an app's main isolate and on the root isolate of a headless
+/// `FlutterEngine`. False only inside an isolate started with `Isolate.spawn`,
+/// which has no engine of its own. Always true on the web, which has no
+/// isolates.
+///
+/// This is a copy of `amplifyIsInRootIsolate` in
+/// `packages/amplify/amplify_flutter/lib/src/amplify_isolate.dart`, which is the
+/// canonical definition — keep the two identical. It is duplicated rather than
+/// imported because `amplify_datastore` does not depend on `amplify_flutter`,
+/// and adding that dependency to share four lines would invert the plugin
+/// dependency graph. The predicate cannot live in `amplify_core`, which is
+/// deliberately Flutter-free.
+/// {@endtemplate}
+@internal
+bool get amplifyIsInRootIsolate {
+  // `RootIsolateToken.instance` throws on the web rather than returning null.
+  if (kIsWeb) return true;
+  return ServicesBinding.rootIsolateToken != null;
+}

--- a/packages/amplify_datastore/test/amplify_datastore_isolate_test.dart
+++ b/packages/amplify_datastore/test/amplify_datastore_isolate_test.dart
@@ -1,0 +1,127 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Guardrail for https://github.com/aws-amplify/amplify-flutter/issues/5302.
+//
+// `AmplifyDataStore` is backed by a process-wide native SDK, so it can only be
+// configured from a root isolate. Verified on device in #7266: a secondary
+// isolate with completely fresh Dart state still meets an already-configured
+// native SDK, which reports `AmplifyAlreadyConfiguredException`.
+
+@TestOn('vm')
+library;
+
+import 'dart:async';
+import 'dart:isolate';
+
+import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore/amplify_datastore.dart';
+import 'package:amplify_datastore/src/isolate_context.dart';
+import 'package:amplify_test/test_models/ModelProvider.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// What [configureInIsolate] observed, sent back over a [SendPort].
+typedef IsolateReport = Map<String, Object?>;
+
+/// Calls `AmplifyDataStore.configure` in the isolate this runs in and reports
+/// which error came back.
+///
+/// A null config is passed deliberately: on a root isolate that produces the
+/// pre-existing `ConfigurationError`, which is what proves the isolate guard did
+/// not fire. In a secondary isolate the guard must win, because being on the
+/// wrong isolate cannot be fixed by supplying a config.
+Future<void> configureInIsolate(SendPort sendPort) async {
+  final report = <String, Object?>{'inRootIsolate': amplifyIsInRootIsolate};
+  final plugin = AmplifyDataStore(modelProvider: ModelProvider.instance);
+  try {
+    await plugin.configure(authProviderRepo: AmplifyAuthProviderRepository());
+    report['errorType'] = null;
+  } on Object catch (e) {
+    report['errorType'] = e.runtimeType.toString();
+    report['error'] = '$e';
+  }
+  sendPort.send(report);
+}
+
+/// Spawns [configureInIsolate] and waits for its [IsolateReport].
+Future<IsolateReport> runInIsolate() async {
+  final receivePort = ReceivePort();
+  final errorPort = ReceivePort();
+  final result = Completer<IsolateReport>();
+
+  receivePort.listen((message) {
+    if (!result.isCompleted) {
+      result.complete((message as Map).cast<String, Object?>());
+    }
+  });
+  errorPort.listen((message) {
+    if (!result.isCompleted) {
+      result.completeError(StateError('Isolate errored: $message'));
+    }
+  });
+
+  final isolate = await Isolate.spawn(
+    configureInIsolate,
+    receivePort.sendPort,
+    onError: errorPort.sendPort,
+    errorsAreFatal: true,
+    debugName: 'datastore-guard',
+  );
+  try {
+    return await result.future.timeout(const Duration(seconds: 30));
+  } finally {
+    isolate.kill(priority: Isolate.immediate);
+    receivePort.close();
+    errorPort.close();
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('amplifyIsInRootIsolate', () {
+    test('is true on a root isolate', () {
+      // Matches the canonical getter in amplify_flutter. `flutter_tester` is an
+      // engine root isolate, the same state a headless `FlutterEngine` runs in.
+      expect(amplifyIsInRootIsolate, isTrue);
+    });
+
+    test('is false in a spawned isolate', () async {
+      final report = await runInIsolate();
+
+      expect(report['inRootIsolate'], isFalse);
+    });
+  });
+
+  group('AmplifyDataStore.configure', () {
+    test('is refused in a secondary isolate, naming the reason', () async {
+      final report = await runInIsolate();
+
+      expect(report['inRootIsolate'], isFalse);
+      expect(report['errorType'], 'PluginError');
+      expect(report['error'], contains('secondary isolate'));
+      expect(
+        report['error'],
+        contains('single instance per process'),
+        reason: 'The message must name the real constraint',
+      );
+      expect(
+        report['error'],
+        contains('root isolate'),
+        reason: 'The message must say where to configure instead',
+      );
+    });
+
+    test('is not refused on the root isolate', () async {
+      // The guard must be invisible to every single-isolate app. Reaching the
+      // pre-existing `ConfigurationError` for the null config proves the guard
+      // did not fire.
+      final plugin = AmplifyDataStore(modelProvider: ModelProvider.instance);
+
+      await expectLater(
+        plugin.configure(authProviderRepo: AmplifyAuthProviderRepository()),
+        throwsA(isA<ConfigurationError>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
⚠️ **Read the last bullet — the Auth and push guards are BLOCKED, and I stopped rather than ship them unverified.** First per-category guardrail for #5302, stacked on #7270.

- `AmplifyDataStore.configure` now fails fast with a `PluginError` in an `Isolate.spawn`ed isolate, naming the real cause (native DataStore is a single instance per process) and where to go instead. Checked before the config check, because being on the wrong isolate cannot be fixed by supplying a config.
- Detection is `ServicesBinding.rootIsolateToken != null` — true for an app main isolate **and** a headless `FlutterEngine`, so it cannot fire in a single-isolate app. Predicate duplicated from the canonical `@internal` getter in `amplify_flutter` (each copy comments the other) because `amplify_datastore` does not depend on `amplify_flutter`; no common Flutter-capable package exists, and `amplify_core` is deliberately Flutter-free.
- 4 new tests, all in CI: guard fires in a secondary isolate with the right message, does **not** fire on the root isolate (reaches the pre-existing `ConfigurationError`). Full suite 121/121 green, zero regression.
- 🛑 **Auth + push guards blocked.** `amplifyBackgroundProcessing` runs `addPlugins([AmplifyAuthCognito(), AmplifyPushNotificationsPinpoint()])` in a headless engine, so **both** those guards depend on the load-bearing claim that a headless `FlutterEngine` reports a non-null root-isolate token — and it **cannot be CI-verified**: the push example has no `e2e_android` leg and no push package in the repo has an `integration_test/` dir. Details in the task report; DataStore is unaffected because it is not in that path.