### PR TITLE
docs: Document the root-isolate requirement for Amplify (#5302)

### DIFF
--- a/packages/amplify/amplify_flutter/README.md
+++ b/packages/amplify/amplify_flutter/README.md
@@ -14,6 +14,32 @@ The top level module for Amplify Flutter.
 | Storage        |   ✅    | ✅  | ✅  |   ✅    |  ✅   |  ✅   |
 | Notifications  |   ✅    | ✅  | 🔴  |   🔴    |  🔴   |  🔴   |
 
+## Isolates
+
+Amplify must be configured and used on the **root isolate** — an app's main
+isolate, or the Dart entry point of a headless `FlutterEngine`.
+
+Dart state is isolate-local, so an isolate started with `Isolate.spawn` can
+construct its own Amplify instance. Two limits make it unsafe to use one:
+
+- **Platform channels only work in one direction.** After
+  `BackgroundIsolateBinaryMessenger.ensureInitialized`, a secondary isolate can
+  call into the host, but it can never receive messages back — Flutter delivers
+  host messages to the root isolate only. Every callback-driven API is therefore
+  root-isolate-only, permanently: DataStore `observe` and Hub events, push
+  notification handlers, and Hosted UI redirects.
+- **Persistent state is shared and not synchronized.** The native SDKs and the
+  credential store are one per process, and Amplify does not serialize access to
+  them across isolates. Two isolates refreshing tokens can interleave their
+  writes and leave an inconsistent credential set.
+
+`AmplifyDataStore.configure` and `AmplifyAuthCognito.addPlugin` fail fast with an
+explanatory error when called from a secondary isolate, rather than failing later
+in a way that is hard to attribute.
+
+Progress on broader isolate support is tracked in
+[#5302](https://github.com/aws-amplify/amplify-flutter/issues/5302).
+
 ## Getting Started
 
 ### Visit our [Web Site](https://docs.amplify.aws/) to learn more about AWS Amplify.


### PR DESCRIPTION
⚠️ **This came out as the opposite of what PR4 was scoped to be — please read bullet 3.** Stacked on #7272. Docs only, no code change.

- Documents the constraint the guardrails enforce, in the `amplify_flutter` README's existing **Category / Platform Support** section (where platform caveats already live).
- Framed on the two bounds that actually apply, not a per-category list: (1) **platform channels are one-way** — a secondary isolate can call into the host but can never receive messages back, so *every* callback-driven API is permanently root-isolate-only (DataStore `observe`/Hub, push handlers, Hosted UI redirect, `NativeAuthPlugin.setUp`); (2) **persistent state is shared and unsynchronized** — the native SDKs and credential store are one per process and nothing serializes access across isolates.
- 🛑 **I did NOT document "configure in any isolate" as a supported feature, and I recommend we do not.** Writing it down honestly showed the safe surface is too thin: `writeMany` in the credential store is `Future.wait` over independent per-key writes with no lock, CAS or versioning anywhere in `amplify_auth_cognito_dart` or `amplify_secure_storage*`, so two isolates refreshing tokens can interleave **per key** and leave a mixed credential set (new access token + old refresh token). That is worse than last-write-wins.
- Consequence: **PR2's helper stays `@internal`** and the user-facing contract should land with the broker that makes it safe. Details and the recommended PR5 reframe are in the task report.