### PR TITLE
fix(ci): Run amplify_auth_cognito Android e2e on macos-26-xlarge

### DIFF
--- a/.github/workflows/amplify_auth_cognito_example.yaml
+++ b/.github/workflows/amplify_auth_cognito_example.yaml
@@ -178,6 +178,7 @@ jobs:
       package-name: amplify_auth_cognito_example
       working-directory: packages/auth/amplify_auth_cognito/example
       needs-aws-config: true
+      runner: macos-26-xlarge
   e2e_ios_test:
     needs: [test]
     uses: ./.github/workflows/e2e_ios.yaml

--- a/.github/workflows/e2e_android.yaml
+++ b/.github/workflows/e2e_android.yaml
@@ -14,10 +14,15 @@ on:
         description: Whether the E2E workflow needs configuration pulled from AWS
         required: true
         type: boolean
+      runner:
+        description: The runner to execute on. Defaults to ubuntu-latest.
+        required: false
+        type: string
+        default: ubuntu-latest
 
 jobs:
   e2e-test-android:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
       id-token: write

--- a/packages/aft/lib/src/commands/generate/generate_workflows_command.dart
+++ b/packages/aft/lib/src/commands/generate/generate_workflows_command.dart
@@ -462,6 +462,14 @@ jobs:
       run-wasm: true
 ''');
         }
+        // Run the auth Android suite on a larger macOS runner; it otherwise
+        // exceeds the emulator's per-attempt timeout on the standard runner.
+        if (platform == 'android' &&
+            package.name == 'amplify_auth_cognito_example') {
+          workflowContents.write('''
+      runner: macos-26-xlarge
+''');
+        }
       }
     }
 


### PR DESCRIPTION
## Description
On the standard Ubuntu runner the auth Android e2e exceeds the emulator's 70 minute per-attempt limit, so each attempt is killed and retried until the job times out. This runs that suite on a larger macOS runner to check whether a stronger machine keeps a single run under the limit.

## Tests
- Confirmed locally that the larger macOS setup supports the emulator, with acceleration and the needed images for both API levels.
- Verified only the auth Android job is affected.

#### Note: Scoped to the auth package for now, since it is the only suite hitting the limit.