### PR TITLE
fix(aft): Stop propagating 2.x versions into 0.x Dart packages

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -103,16 +103,25 @@ aft:
         - amplify_secure_storage_dart
     - name: Kinesis
       summary: amplify_kinesis
+      # The Flutter and Dart packages are on independent version lines
+      # (2.x and 0.x). Propagating would bump the Dart package to 2.x.
+      propagate: none
       packages:
         - amplify_kinesis
         - amplify_kinesis_dart
     - name: Firehose
       summary: amplify_firehose
+      # The Flutter and Dart packages are on independent version lines
+      # (2.x and 0.x). Propagating would bump the Dart package to 2.x.
+      propagate: none
       packages:
         - amplify_firehose
         - amplify_firehose_dart
     - name: Connect
       summary: amplify_connect_client
+      # The Flutter and Dart packages are on independent version lines
+      # (2.x and 0.x). Propagating would bump the Dart package to 2.x.
+      propagate: none
       packages:
         - amplify_connect_client
         - amplify_connect_client_dart


### PR DESCRIPTION
The `Kinesis` and `Firehose` components group a 2.x Flutter package with a 0.x Dart package but did not set `propagate`, so they defaulted to `VersionPropagation.minor`. When the summary package took a minor bump, the component version won the `maxBy` in `Repo.bumpVersion`, dragging the Dart packages onto the Flutter version line:

  amplify_firehose_dart: 0.1.4 -> 2.14.0
  amplify_kinesis_dart:  0.1.5 -> 2.13.0

Both packages have only ever published a 0.1.x line, and a publish is irreversible, so this would have permanently retired those lines.

Set `propagate: none` on `Kinesis`, `Firehose` and `Connect` — matching the existing `Amplify Dart` component, which pairs 2.x and 0.x packages for the same reason — and correct the two versions to the patch bumps they should have received. `Connect` escaped this cycle only because it took a patch bump; it would have hit the same problem on its next minor bump.

Problem was found here: https://github.com/aws-amplify/amplify-flutter/pull/7283