### PR TITLE
chore: Regenerate files for Flutter 3.47

### DIFF
--- a/canaries/analysis_options.yaml
+++ b/canaries/analysis_options.yaml
@@ -3,3 +3,10 @@ include: package:amplify_lints/app.yaml
 analyzer:
   exclude:
     - lib/models/*
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**

--- a/packages/amplify/amplify_flutter/analysis_options.yaml
+++ b/packages/amplify/amplify_flutter/analysis_options.yaml
@@ -3,3 +3,10 @@ include: package:amplify_lints/library.yaml
 analyzer:
   exclude:
     - lib/**/*.g.dart
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**

--- a/packages/amplify/amplify_flutter/example/analysis_options.yaml
+++ b/packages/amplify/amplify_flutter/example/analysis_options.yaml
@@ -1,1 +1,10 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:amplify_lints/app.yaml

--- a/packages/amplify/amplify_flutter/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/amplify/amplify_flutter/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -10,6 +10,7 @@ import amplify_secure_storage
 import connectivity_plus
 import device_info_plus
 import package_info_plus
+import path_provider_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AmplifyAuthCognitoPlugin.register(with: registry.registrar(forPlugin: "AmplifyAuthCognitoPlugin"))
@@ -17,4 +18,5 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
+  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
 }

--- a/packages/amplify_connect_client/amplify_connect_client/analysis_options.yaml
+++ b/packages/amplify_connect_client/amplify_connect_client/analysis_options.yaml
@@ -1,1 +1,10 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:amplify_lints/library.yaml

--- a/packages/amplify_connect_client/amplify_connect_client/example/analysis_options.yaml
+++ b/packages/amplify_connect_client/amplify_connect_client/example/analysis_options.yaml
@@ -1,1 +1,10 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:amplify_lints/app.yaml

--- a/packages/amplify_connect_client/amplify_connect_client/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/amplify_connect_client/amplify_connect_client/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -9,6 +9,7 @@ import amplify_auth_cognito
 import amplify_secure_storage
 import device_info_plus
 import package_info_plus
+import path_provider_foundation
 import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
@@ -16,5 +17,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AmplifySecureStoragePlugin.register(with: registry.registrar(forPlugin: "AmplifySecureStoragePlugin"))
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
+  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }

--- a/packages/amplify_core/doc/analysis_options.yaml
+++ b/packages/amplify_core/doc/analysis_options.yaml
@@ -4,3 +4,11 @@ analyzer:
   errors:
     public_member_api_docs: ignore
     unused_local_variable: ignore
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**

--- a/packages/amplify_datastore_plugin_interface/analysis_options.yaml
+++ b/packages/amplify_datastore_plugin_interface/analysis_options.yaml
@@ -1,3 +1,10 @@
 analyzer:
   exclude:
     - test
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**

--- a/packages/amplify_native_legacy_wrapper/analysis_options.yaml
+++ b/packages/amplify_native_legacy_wrapper/analysis_options.yaml
@@ -3,3 +3,10 @@ include: package:amplify_lints/library.yaml
 analyzer:
   exclude:
     - "**/*.g.dart"
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**

--- a/packages/amplify_native_legacy_wrapper/example/analysis_options.yaml
+++ b/packages/amplify_native_legacy_wrapper/example/analysis_options.yaml
@@ -1,1 +1,10 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:amplify_lints/app.yaml

--- a/packages/analytics/amplify_analytics_pinpoint/analysis_options.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint/analysis_options.yaml
@@ -5,3 +5,10 @@ analyzer:
     implementation_imports: error #TODO(equartey): Remove when lint is enforced project-wide
   exclude:
     - "**/*.g.dart"
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**

--- a/packages/analytics/amplify_analytics_pinpoint/example/analysis_options.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint/example/analysis_options.yaml
@@ -1,1 +1,10 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:amplify_lints/app.yaml

--- a/packages/analytics/amplify_analytics_pinpoint/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/analytics/amplify_analytics_pinpoint/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -10,6 +10,7 @@ import amplify_secure_storage
 import connectivity_plus
 import device_info_plus
 import package_info_plus
+import path_provider_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AmplifyAuthCognitoPlugin.register(with: registry.registrar(forPlugin: "AmplifyAuthCognitoPlugin"))
@@ -17,4 +18,5 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
+  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
 }

--- a/packages/analytics/amplify_analytics_pinpoint/pubspec.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint/pubspec.yaml
@@ -20,9 +20,9 @@ platforms:
 
 dependencies:
   amplify_analytics_pinpoint_dart: ">=0.4.20 <0.5.0"
-  amplify_core: ">=2.15.0 <2.16.0"
-  amplify_db_common: ">=0.4.21 <0.5.0"
-  amplify_secure_storage: ">=0.5.21 <0.6.0"
+  amplify_core: ">=2.14.0 <2.15.0"
+  amplify_db_common: ">=0.4.20 <0.5.0"
+  amplify_secure_storage: ">=0.5.20 <0.6.0"
   aws_common: ">=0.7.15 <0.8.0"
   device_info_plus: ^13.1.0
 

--- a/packages/analytics/amplify_analytics_pinpoint/pubspec.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_analytics_pinpoint
 description: The Amplify Flutter Analytics category plugin using the AWS Pinpoint provider.
-version: 2.15.0
+version: 2.14.0
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/analytics/amplify_analytics_pinpoint
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues

--- a/packages/analytics/amplify_analytics_pinpoint/pubspec.yaml
+++ b/packages/analytics/amplify_analytics_pinpoint/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_analytics_pinpoint
 description: The Amplify Flutter Analytics category plugin using the AWS Pinpoint provider.
-version: 2.14.0
+version: 2.15.0
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/analytics/amplify_analytics_pinpoint
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
@@ -20,9 +20,9 @@ platforms:
 
 dependencies:
   amplify_analytics_pinpoint_dart: ">=0.4.20 <0.5.0"
-  amplify_core: ">=2.14.0 <2.15.0"
-  amplify_db_common: ">=0.4.20 <0.5.0"
-  amplify_secure_storage: ">=0.5.20 <0.6.0"
+  amplify_core: ">=2.15.0 <2.16.0"
+  amplify_db_common: ">=0.4.21 <0.5.0"
+  amplify_secure_storage: ">=0.5.21 <0.6.0"
   aws_common: ">=0.7.15 <0.8.0"
   device_info_plus: ^13.1.0
 

--- a/packages/api/amplify_api/analysis_options.yaml
+++ b/packages/api/amplify_api/analysis_options.yaml
@@ -4,3 +4,10 @@ analyzer:
   exclude:
     - '**/*.mocks.dart'
     - lib/src/native_api_plugin.dart
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**

--- a/packages/api/amplify_api/example/analysis_options.yaml
+++ b/packages/api/amplify_api/example/analysis_options.yaml
@@ -3,6 +3,13 @@ include: package:amplify_lints/app.yaml
 analyzer:
   exclude:
     - lib/models/*
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 
 linter:
   rules:

--- a/packages/api/amplify_api/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/api/amplify_api/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -10,6 +10,7 @@ import amplify_secure_storage
 import connectivity_plus
 import device_info_plus
 import package_info_plus
+import path_provider_foundation
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
@@ -18,5 +19,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
+  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/packages/auth/amplify_auth_cognito/analysis_options.yaml
+++ b/packages/auth/amplify_auth_cognito/analysis_options.yaml
@@ -5,3 +5,10 @@ analyzer:
     - lib/**/*.g.dart
     - lib/src/sdk/src/**
     - lib/src/native_auth_plugin.dart
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**

--- a/packages/auth/amplify_auth_cognito/example/analysis_options.yaml
+++ b/packages/auth/amplify_auth_cognito/example/analysis_options.yaml
@@ -1,1 +1,10 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:amplify_lints/app.yaml

--- a/packages/auth/amplify_auth_cognito/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/auth/amplify_auth_cognito/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -10,6 +10,7 @@ import amplify_secure_storage
 import connectivity_plus
 import device_info_plus
 import package_info_plus
+import path_provider_foundation
 import url_launcher_macos
 import webview_flutter_wkwebview
 
@@ -19,6 +20,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
+  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
   FLTWebViewFlutterPlugin.register(with: registry.registrar(forPlugin: "FLTWebViewFlutterPlugin"))
 }

--- a/packages/authenticator/amplify_authenticator/analysis_options.yaml
+++ b/packages/authenticator/amplify_authenticator/analysis_options.yaml
@@ -3,5 +3,12 @@ include: package:amplify_lints/library.yaml
 analyzer:
   exclude:
     - tool/*.dart
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
   errors:
     public_member_api_docs: ignore

--- a/packages/authenticator/amplify_authenticator/example/analysis_options.yaml
+++ b/packages/authenticator/amplify_authenticator/example/analysis_options.yaml
@@ -3,3 +3,11 @@ include: package:amplify_lints/app.yaml
 analyzer:
   errors:
     avoid_print: ignore
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**

--- a/packages/authenticator/amplify_authenticator/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/authenticator/amplify_authenticator/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -10,6 +10,7 @@ import amplify_secure_storage
 import connectivity_plus
 import device_info_plus
 import package_info_plus
+import path_provider_foundation
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
@@ -18,5 +19,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
+  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/packages/authenticator/amplify_authenticator_test/analysis_options.yaml
+++ b/packages/authenticator/amplify_authenticator_test/analysis_options.yaml
@@ -3,3 +3,11 @@ include: package:amplify_lints/library.yaml
 analyzer:
   errors:
     public_member_api_docs: ignore
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**

--- a/packages/authenticator/amplify_authenticator_test/example/analysis_options.yaml
+++ b/packages/authenticator/amplify_authenticator_test/example/analysis_options.yaml
@@ -1,1 +1,10 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:flutter_lints/flutter.yaml

--- a/packages/authenticator/amplify_authenticator_test/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/authenticator/amplify_authenticator_test/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -9,6 +9,7 @@ import amplify_auth_cognito
 import amplify_secure_storage
 import device_info_plus
 import package_info_plus
+import path_provider_foundation
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
@@ -16,5 +17,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AmplifySecureStoragePlugin.register(with: registry.registrar(forPlugin: "AmplifySecureStoragePlugin"))
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
+  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/packages/common/amplify_db_common/analysis_options.yaml
+++ b/packages/common/amplify_db_common/analysis_options.yaml
@@ -1,1 +1,10 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:amplify_lints/library.yaml

--- a/packages/common/amplify_db_common/example/analysis_options.yaml
+++ b/packages/common/amplify_db_common/example/analysis_options.yaml
@@ -7,6 +7,15 @@
 
 # The following line activates a set of recommended lints for Flutter apps,
 # packages, and plugins designed to encourage good coding practices.
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:flutter_lints/flutter.yaml
 
 linter:

--- a/packages/common/amplify_db_common/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/common/amplify_db_common/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,8 @@
 import FlutterMacOS
 import Foundation
 
+import path_provider_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
 }

--- a/packages/kinesis/amplify_firehose/analysis_options.yaml
+++ b/packages/kinesis/amplify_firehose/analysis_options.yaml
@@ -1,1 +1,10 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:amplify_lints/library.yaml

--- a/packages/kinesis/amplify_firehose/example/analysis_options.yaml
+++ b/packages/kinesis/amplify_firehose/example/analysis_options.yaml
@@ -1,1 +1,10 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:amplify_lints/app.yaml

--- a/packages/kinesis/amplify_firehose/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/kinesis/amplify_firehose/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -9,6 +9,7 @@ import amplify_auth_cognito
 import amplify_secure_storage
 import device_info_plus
 import package_info_plus
+import path_provider_foundation
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
@@ -16,5 +17,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AmplifySecureStoragePlugin.register(with: registry.registrar(forPlugin: "AmplifySecureStoragePlugin"))
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
+  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/packages/kinesis/amplify_kinesis/analysis_options.yaml
+++ b/packages/kinesis/amplify_kinesis/analysis_options.yaml
@@ -4,3 +4,10 @@ analyzer:
   exclude:
     - '**/*.g.dart'
     - 'lib/src/sdk/src/**'
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**

--- a/packages/kinesis/amplify_kinesis/example/analysis_options.yaml
+++ b/packages/kinesis/amplify_kinesis/example/analysis_options.yaml
@@ -1,1 +1,10 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:amplify_lints/app.yaml

--- a/packages/kinesis/amplify_kinesis/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/kinesis/amplify_kinesis/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -9,6 +9,7 @@ import amplify_auth_cognito
 import amplify_secure_storage
 import device_info_plus
 import package_info_plus
+import path_provider_foundation
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
@@ -16,5 +17,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AmplifySecureStoragePlugin.register(with: registry.registrar(forPlugin: "AmplifySecureStoragePlugin"))
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
+  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/packages/notifications/push/amplify_push_notifications/analysis_options.yaml
+++ b/packages/notifications/push/amplify_push_notifications/analysis_options.yaml
@@ -4,3 +4,10 @@ analyzer:
   exclude:
     - "**/*.g.dart"
     - "**/*.mocks.dart"
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**

--- a/packages/notifications/push/amplify_push_notifications/example/analysis_options.yaml
+++ b/packages/notifications/push/amplify_push_notifications/example/analysis_options.yaml
@@ -1,1 +1,10 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:amplify_lints/app.yaml

--- a/packages/notifications/push/amplify_push_notifications_pinpoint/analysis_options.yaml
+++ b/packages/notifications/push/amplify_push_notifications_pinpoint/analysis_options.yaml
@@ -3,3 +3,10 @@ include: package:amplify_lints/library.yaml
 analyzer:
   exclude:
     - "**/*.g.dart"
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**

--- a/packages/notifications/push/amplify_push_notifications_pinpoint/example/analysis_options.yaml
+++ b/packages/notifications/push/amplify_push_notifications_pinpoint/example/analysis_options.yaml
@@ -1,3 +1,12 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:amplify_lints/app.yaml
 
 linter:

--- a/packages/secure_storage/amplify_secure_storage/analysis_options.yaml
+++ b/packages/secure_storage/amplify_secure_storage/analysis_options.yaml
@@ -3,6 +3,13 @@ include: package:amplify_lints/library.yaml
 analyzer:
   exclude:
     - "**/*.g.dart"
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
   errors:
     implementation_imports: error    
 

--- a/packages/secure_storage/amplify_secure_storage/example/analysis_options.yaml
+++ b/packages/secure_storage/amplify_secure_storage/example/analysis_options.yaml
@@ -1,1 +1,10 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:amplify_lints/app.yaml

--- a/packages/storage/amplify_storage_s3/analysis_options.yaml
+++ b/packages/storage/amplify_storage_s3/analysis_options.yaml
@@ -3,3 +3,10 @@ include: package:amplify_lints/library.yaml
 analyzer:
   exclude:
     - '**/*.g.dart'
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**

--- a/packages/storage/amplify_storage_s3/example/analysis_options.yaml
+++ b/packages/storage/amplify_storage_s3/example/analysis_options.yaml
@@ -1,1 +1,10 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:amplify_lints/app.yaml

--- a/packages/storage/amplify_storage_s3/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/storage/amplify_storage_s3/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -10,6 +10,7 @@ import amplify_secure_storage
 import device_info_plus
 import file_selector_macos
 import package_info_plus
+import path_provider_foundation
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
@@ -18,5 +19,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
+  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/packages/test/amplify_auth_integration_test/analysis_options.yaml
+++ b/packages/test/amplify_auth_integration_test/analysis_options.yaml
@@ -1,1 +1,10 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:amplify_lints/library.yaml

--- a/packages/worker_bee/e2e_flutter_test/analysis_options.yaml
+++ b/packages/worker_bee/e2e_flutter_test/analysis_options.yaml
@@ -1,1 +1,10 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:amplify_lints/app.yaml

--- a/packages/worker_bee/worker_bee/example/analysis_options.yaml
+++ b/packages/worker_bee/worker_bee/example/analysis_options.yaml
@@ -4,3 +4,10 @@ analyzer:
     - '**/*.worker.js.dart'
     - '**/*.worker.vm.dart'
     - '**/*.worker.dart'
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**


### PR DESCRIPTION
Flutter 3.47.0 added `AnalysisOptionsMigration` (flutter/flutter#187940), which runs on `flutter pub get` and appends `build/**` plus the platform directories to each project's `analysis_options.yaml`. The same `pub get` also regenerates the macOS plugin registrants, which pick up `path_provider_foundation` again in the examples whose graph resolves it to 2.5.1 — 2.6.0 dropped the native `pluginClass` in favor of Dart-only registration.

Applying this repo-wide keeps the churn out of unrelated commits, e.g. the `aft version-bump` workflow, which runs `flutter pub get` in `amplify_authenticator` and commits with `git add -A`.

Generated with `aft bootstrap --no-upgrade --no-build` on Flutter 3.47.0.

That regeneration is needed was found here: https://github.com/aws-amplify/amplify-flutter/pull/7283