### PR TITLE
chore: Reformat integration tests for the Dart 3.13 formatter

### DIFF
--- a/packages/analytics/amplify_analytics_pinpoint/example/integration_test/identify_user_test.dart
+++ b/packages/analytics/amplify_analytics_pinpoint/example/integration_test/identify_user_test.dart
@@ -25,110 +25,108 @@ void main() {
       eventsStream = await subscribeToEvents();
     });
 
-    testWidgets(
-      'properties of identityUser() added to all future events',
-      (_) async {
-        final userId = DateTime.now().toIso8601String();
-        const name = 'name';
-        const email = 'email';
-        const plan = 'plan';
+    testWidgets('properties of identityUser() added to all future events', (
+      _,
+    ) async {
+      final userId = DateTime.now().toIso8601String();
+      const name = 'name';
+      const email = 'email';
+      const plan = 'plan';
 
-        const latitude = 43.0;
-        const longitude = 12.0;
-        const postalCode = '94070';
-        const city = 'city';
-        const region = 'region';
-        const country = 'USA';
+      const latitude = 43.0;
+      const longitude = 12.0;
+      const postalCode = '94070';
+      const city = 'city';
+      const region = 'region';
+      const country = 'USA';
 
-        const location = UserProfileLocation(
-          latitude: latitude,
-          longitude: longitude,
-          postalCode: postalCode,
-          city: city,
-          region: region,
-          country: country,
-        );
+      const location = UserProfileLocation(
+        latitude: latitude,
+        longitude: longitude,
+        postalCode: postalCode,
+        city: city,
+        region: region,
+        country: country,
+      );
 
-        final properties = CustomProperties()
-          ..addBoolProperty(boolProperty.key, boolProperty.value)
-          ..addDoubleProperty(doubleProperty.key, doubleProperty.value)
-          ..addIntProperty(intProperty.key, intProperty.value)
-          ..addStringProperty(stringProperty.key, stringProperty.value);
+      final properties = CustomProperties()
+        ..addBoolProperty(boolProperty.key, boolProperty.value)
+        ..addDoubleProperty(doubleProperty.key, doubleProperty.value)
+        ..addIntProperty(intProperty.key, intProperty.value)
+        ..addStringProperty(stringProperty.key, stringProperty.value);
 
-        await Amplify.Analytics.identifyUser(
-          userId: userId,
-          userProfile: AWSPinpointUserProfile(
-            name: name,
-            email: email,
-            plan: plan,
-            location: location,
-            customProperties: properties,
-            userAttributes: {
-              stringProperty.key: [stringProperty.value, stringProperty.value],
-            },
-          ),
-        );
+      await Amplify.Analytics.identifyUser(
+        userId: userId,
+        userProfile: AWSPinpointUserProfile(
+          name: name,
+          email: email,
+          plan: plan,
+          location: location,
+          customProperties: properties,
+          userAttributes: {
+            stringProperty.key: [stringProperty.value, stringProperty.value],
+          },
+        ),
+      );
 
-        const customEventName = 'identify user event name';
-        final customEvent = AnalyticsEvent(customEventName);
+      const customEventName = 'identify user event name';
+      final customEvent = AnalyticsEvent(customEventName);
 
-        await Amplify.Analytics.recordEvent(event: customEvent);
-        await Amplify.Analytics.flushEvents();
+      await Amplify.Analytics.recordEvent(event: customEvent);
+      await Amplify.Analytics.flushEvents();
 
-        await expectLater(
-          eventsStream,
-          emits(
-            isA<TestEvent>()
-                .having((e) => e.eventType, 'eventType', customEventName)
-                .having(
-                  (e) => e.endpoint.endpointStatus,
-                  'EndpointStatus',
-                  'ACTIVE',
-                )
-                .having((e) => e.endpoint.optOut, 'OptOut', 'ALL')
-                .having(
-                  (e) => e.endpoint.location,
-                  'Location',
-                  EndpointLocation(
-                    latitude: latitude,
-                    longitude: longitude,
-                    postalCode: postalCode,
-                    city: city,
-                    region: region,
-                    country: country,
-                  ),
-                )
-                .having((e) => e.endpoint.user?.userId, 'UserId', userId)
-                .having(
-                  (e) => e.endpoint.user?.userAttributes?.toMap() ?? const {},
-                  'UserAttributes',
-                  equals({
-                    stringProperty.key: [
-                      stringProperty.value,
-                      stringProperty.value,
-                    ],
-                  }),
-                )
-                .having(
-                  (e) => e.endpoint.attributes?.toMap() ?? const {},
-                  'Attributes',
-                  equals({
-                    boolProperty.key: [stringifiedBoolProperty.value],
-                    stringProperty.key: [stringProperty.value],
-                    'name': [name],
-                    'plan': [plan],
-                    'email': [email],
-                  }),
-                )
-                .having(
-                  (e) => e.endpoint.metrics?.toMap() ?? const {},
-                  'Metrics',
-                  equals(Map.fromEntries([lossyDoubleProperty, intProperty])),
+      await expectLater(
+        eventsStream,
+        emits(
+          isA<TestEvent>()
+              .having((e) => e.eventType, 'eventType', customEventName)
+              .having(
+                (e) => e.endpoint.endpointStatus,
+                'EndpointStatus',
+                'ACTIVE',
+              )
+              .having((e) => e.endpoint.optOut, 'OptOut', 'ALL')
+              .having(
+                (e) => e.endpoint.location,
+                'Location',
+                EndpointLocation(
+                  latitude: latitude,
+                  longitude: longitude,
+                  postalCode: postalCode,
+                  city: city,
+                  region: region,
+                  country: country,
                 ),
-          ),
-        );
-      },
-      timeout: const Timeout(Duration(minutes: 3)),
-    );
+              )
+              .having((e) => e.endpoint.user?.userId, 'UserId', userId)
+              .having(
+                (e) => e.endpoint.user?.userAttributes?.toMap() ?? const {},
+                'UserAttributes',
+                equals({
+                  stringProperty.key: [
+                    stringProperty.value,
+                    stringProperty.value,
+                  ],
+                }),
+              )
+              .having(
+                (e) => e.endpoint.attributes?.toMap() ?? const {},
+                'Attributes',
+                equals({
+                  boolProperty.key: [stringifiedBoolProperty.value],
+                  stringProperty.key: [stringProperty.value],
+                  'name': [name],
+                  'plan': [plan],
+                  'email': [email],
+                }),
+              )
+              .having(
+                (e) => e.endpoint.metrics?.toMap() ?? const {},
+                'Metrics',
+                equals(Map.fromEntries([lossyDoubleProperty, intProperty])),
+              ),
+        ),
+      );
+    }, timeout: const Timeout(Duration(minutes: 3)));
   });
 }

--- a/packages/auth/amplify_auth_cognito/example/integration_test/sign_in_test.dart
+++ b/packages/auth/amplify_auth_cognito/example/integration_test/sign_in_test.dart
@@ -97,60 +97,56 @@ void main() {
           expect(result.nextStep.additionalInfo, isEmpty);
         });
 
-        asyncTest(
-          'identity ID should be the same between sessions',
-          (_) async {
-            // Get unauthenticated identity
-            final unauthSession =
-                await Amplify.Auth.fetchAuthSession() as CognitoAuthSession;
+        asyncTest('identity ID should be the same between sessions', (_) async {
+          // Get unauthenticated identity
+          final unauthSession =
+              await Amplify.Auth.fetchAuthSession() as CognitoAuthSession;
 
-            // Sign in
-            {
-              final signInRes = await Amplify.Auth.signIn(
-                username: username,
-                password: password,
-              );
-              expect(signInRes.nextStep.signInStep, AuthSignInStep.done);
-            }
-
-            // Get authenticated identity
-            final authSession =
-                await Amplify.Auth.fetchAuthSession() as CognitoAuthSession;
-            final authenticatedIdentity = authSession.identityIdResult;
-            expect(
-              authenticatedIdentity,
-              isNot(unauthSession.identityIdResult.value),
-              reason:
-                  'Unauthenticated identities should be distinct from authenticated '
-                  'identities, since unauthenticated identities are vended to all '
-                  'new devices when guest access is enabled but should converge to '
-                  'a singular authenticated identity across all devices',
+          // Sign in
+          {
+            final signInRes = await Amplify.Auth.signIn(
+              username: username,
+              password: password,
             );
-            expect(
-              authSession.credentialsResult.value,
-              isNot(unauthSession.credentialsResult.value),
-            );
+            expect(signInRes.nextStep.signInStep, AuthSignInStep.done);
+          }
 
-            await Amplify.Auth.signOut();
-            {
-              final signInRes = await Amplify.Auth.signIn(
-                username: username,
-                password: password,
-              );
-              expect(signInRes.nextStep.signInStep, AuthSignInStep.done);
-            }
+          // Get authenticated identity
+          final authSession =
+              await Amplify.Auth.fetchAuthSession() as CognitoAuthSession;
+          final authenticatedIdentity = authSession.identityIdResult;
+          expect(
+            authenticatedIdentity,
+            isNot(unauthSession.identityIdResult.value),
+            reason:
+                'Unauthenticated identities should be distinct from authenticated '
+                'identities, since unauthenticated identities are vended to all '
+                'new devices when guest access is enabled but should converge to '
+                'a singular authenticated identity across all devices',
+          );
+          expect(
+            authSession.credentialsResult.value,
+            isNot(unauthSession.credentialsResult.value),
+          );
 
-            final newSession =
-                await Amplify.Auth.fetchAuthSession() as CognitoAuthSession;
-            expect(
-              newSession.identityIdResult.value,
-              authenticatedIdentity.value,
-              reason:
-                  'Authenticated identity should be the same between sessions',
+          await Amplify.Auth.signOut();
+          {
+            final signInRes = await Amplify.Auth.signIn(
+              username: username,
+              password: password,
             );
-          },
-          skip: environment.name == 'user-pool-only',
-        );
+            expect(signInRes.nextStep.signInStep, AuthSignInStep.done);
+          }
+
+          final newSession =
+              await Amplify.Auth.fetchAuthSession() as CognitoAuthSession;
+          expect(
+            newSession.identityIdResult.value,
+            authenticatedIdentity.value,
+            reason:
+                'Authenticated identity should be the same between sessions',
+          );
+        }, skip: environment.name == 'user-pool-only');
       });
     }
   });


### PR DESCRIPTION
`dart format` from Flutter 3.47.0 (Dart 3.13.0) rewraps the trailing function-literal arguments in these two `testWidgets` calls, so the `Check Formatting` step failed for `amplify_analytics_pinpoint`, `amplify_analytics_pinpoint_example`, `amplify_auth_cognito` and `amplify_auth_cognito_example`.

Formatting only, no behavior change.
