### PR TITLE
chore(api): One-time purge of accumulated e2e Blog rows

### DIFF
--- a/packages/api/amplify_api/example/integration_test/cleanup_blogs.dart
+++ b/packages/api/amplify_api/example/integration_test/cleanup_blogs.dart
@@ -1,0 +1,54 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_api/amplify_api.dart';
+import 'package:amplify_api_example/models/ModelProvider.dart';
+import 'package:amplify_flutter/amplify_flutter.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Deletes every `Blog` from the shared e2e backend in a single paginated pass.
+Future<void> purgeAllBlogs() async {
+  var deleted = 0;
+  var failed = 0;
+  GraphQLRequest<PaginatedResult<Blog>>? request = ModelQueries.list<Blog>(
+    Blog.classType,
+    limit: 1000,
+  );
+
+  while (request != null) {
+    final res = await Amplify.API.query(request: request).response;
+    if (res.hasErrors) {
+      fail('Cleanup list query failed: ${res.errors}');
+    }
+    final data = res.data;
+    final blogs = (data?.items ?? const <Blog?>[]).whereType<Blog>().toList();
+
+    for (var i = 0; i < blogs.length; i += 25) {
+      final end = (i + 25 < blogs.length) ? i + 25 : blogs.length;
+      final results = await Future.wait(
+        blogs
+            .sublist(i, end)
+            .map(
+              (blog) => Amplify.API
+                  .mutate(
+                    request: ModelMutations.deleteById(
+                      Blog.classType,
+                      blog.modelIdentifier,
+                      authorizationMode: APIAuthorizationType.userPools,
+                    ),
+                  )
+                  .response,
+            ),
+      );
+      for (final result in results) {
+        result.hasErrors ? failed++ : deleted++;
+      }
+    }
+
+    request = (data?.hasNextResult ?? false)
+        ? data!.requestForNextResult
+        : null;
+  }
+
+  safePrint('CLEANUP: deleted=$deleted failed=$failed');
+}

--- a/packages/api/amplify_api/example/integration_test/main_test.dart
+++ b/packages/api/amplify_api/example/integration_test/main_test.dart
@@ -6,6 +6,7 @@ import 'package:amplify_integration_test/amplify_integration_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
+import 'cleanup_blogs.dart';
 import 'graphql/api_key_test.dart' as graph_api_key_test;
 import 'graphql/iam_test.dart' as graph_iam_test;
 import 'graphql/user_pools_test.dart' as graph_user_pools_test;
@@ -61,5 +62,11 @@ void main() async {
     graph_user_pools_test.main(useExistingTestUser: true, testUser: testUser);
 
     rest_test.main(useExistingTestUser: true, testUser: testUser);
+
+    // TEMP one-time maintenance (remove after it runs once): purge the
+    // accumulated Blog backlog that makes the list-predicate tests flaky.
+    testWidgets('CLEANUP purge all blogs', (tester) async {
+      await purgeAllBlogs();
+    }, timeout: const Timeout(Duration(minutes: 30)));
   });
 }


### PR DESCRIPTION
## Description
The shared `amplify_api` e2e backend has accumulated thousands of `Blog` rows from prior runs whose cleanup was interrupted, pushing the table past one DynamoDB scan page and making the list-predicate tests flaky. This adds a one-time maintenance step that pages through and deletes all Blogs; it should be reverted once it has run.