### PR TITLE
feat(aft): Retry `prePublish` for 20min

### DIFF
--- a/packages/aft/lib/src/commands/publish_command.dart
+++ b/packages/aft/lib/src/commands/publish_command.dart
@@ -23,6 +23,12 @@ mixin PublishHelpers on AmplifyCommand {
   /// Names of packages that are not yet published on pub.dev.
   final Set<String> _newPackages = {};
 
+  /// How long pre-publish keeps retrying `pub upgrade` before giving up.
+  static const _pubUpgradeTimeout = Duration(minutes: 20);
+
+  /// How long to wait between `pub upgrade` attempts.
+  static const _pubUpgradeRetryInterval = Duration(seconds: 60);
+
   /// Gathers the subset of packages which are publishable and whose latest
   /// version is not already available on `pub.dev`.
   Future<List<PackageInfo>> unpublishedPackages(
@@ -122,19 +128,43 @@ mixin PublishHelpers on AmplifyCommand {
         pubspecOverrideFile.deleteSync();
       }
     }
-    final res = await Process.run(
-      package.flavor.entrypoint,
-      ['pub', 'upgrade'],
-      stdoutEncoding: utf8,
-      stderrEncoding: utf8,
-      workingDirectory: package.path,
-    );
-    if (res.exitCode != 0) {
-      stdout.write(res.stdout);
-      stderr.write(res.stderr);
-      exit(res.exitCode);
-    }
+    await _pubUpgrade(package);
     await runBuildRunner(package, logger: logger, verbose: verbose);
+  }
+
+  /// Runs `pub upgrade` for [package], retrying until [_pubUpgradeTimeout].
+  ///
+  /// A version takes a few minutes to become resolvable by `pub` after being
+  /// published, so this failing right after a dependency was published usually
+  /// means propagation, not a broken constraint. Retrying keeps that from
+  /// aborting a release halfway through — the alternative is a re-run, which
+  /// lands in the same window and fails again.
+  Future<void> _pubUpgrade(PackageInfo package) async {
+    final stopwatch = Stopwatch()..start();
+    while (true) {
+      final res = await Process.run(
+        package.flavor.entrypoint,
+        ['pub', 'upgrade'],
+        stdoutEncoding: utf8,
+        stderrEncoding: utf8,
+        workingDirectory: package.path,
+      );
+      if (res.exitCode == 0) {
+        return;
+      }
+      if (stopwatch.elapsed + _pubUpgradeRetryInterval >= _pubUpgradeTimeout) {
+        stdout.write(res.stdout);
+        stderr.write(res.stderr);
+        exit(res.exitCode);
+      }
+      logger.warn(
+        '`${package.flavor.entrypoint} pub upgrade` failed for '
+        '${package.name}. Retrying in '
+        '${_pubUpgradeRetryInterval.inSeconds}s — a version just published to '
+        '`pub.dev` can take a few minutes to resolve.',
+      );
+      await Future<void>.delayed(_pubUpgradeRetryInterval);
+    }
   }
 
   static final _validationStartRegex = RegExp(


### PR DESCRIPTION
Transitive dependencies caused this:
```
  Proceed with publish (y/N)? y                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                     
  Publish queue (ready to publish):                                                                                                                                                                                                                                                                                  
  - amplify_storage_s3_dart (0.4.23)                                                                                                                                                                                                                                                                                 
  - amplify_db_common (0.4.21)                                                                                                                                                                                                                                                                                       
  - amplify_push_notifications (2.15.0)                                                                                                                                                                                                                                                                              
  - amplify_flutter (2.15.0)                                                                                                                                                                                                                                                                                         
  - amplify_analytics_pinpoint_dart (0.4.21)                                                                                                                                                                                                                                                                         
  - amplify_kinesis_dart (0.1.6)                                                                                                                                                                                                                                                                                     
  - amplify_firehose_dart (0.1.5)                                                                                                                                                                                                                                                                                    
  - amplify_api_dart (0.5.22)                                                                                                                                                                                                                                                                                        
  - amplify_datastore_plugin_interface (2.15.0)                                                                                                                                                                                                                                                                      
  Running pre-publish checks for amplify_storage_s3_dart...                                                                                                                                                                                                                                                          
  Resolving dependencies...                                                                                                                                                                                                                                                                                          
  Because amplify_db_common_dart >=0.4.20 <0.4.21 depends on amplify_core >=2.12.1 <2.13.0 and amplify_db_common_dart >=0.4.21 <0.4.22 depends on amplify_core >=2.13.0 <2.14.0, amplify_db_common_dart >=0.4.20 <0.4.22 requires amplify_core >=2.12.1 <2.13.0 or >=2.13.0 <2.14.0.                                 
  And because amplify_db_common_dart >=0.4.22 depends on amplify_core >=2.14.0 <2.15.0, amplify_db_common_dart >=0.4.20 requires amplify_core >=2.12.1 <2.13.0 or >=2.13.0 <2.14.0 or >=2.14.0 <2.15.0.                                                                                                              
  So, because amplify_storage_s3_dart depends on both amplify_core >=2.15.0 <2.16.0 and amplify_db_common_dart ^0.4.20, version solving failed.                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                     
  You can try the following suggestion to make the pubspec resolve:                                                                                                                                                                                                                                                  
  - Consider downgrading your constraint on amplify_core: dart pub add amplify_core:^2.14.0  
```

This PR fixes it.