### PR TITLE
fix(authenticator): enforce required validation for empty phone number field

### DIFF
--- a/packages/authenticator/amplify_authenticator/lib/src/mixins/authenticator_phone_field.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/mixins/authenticator_phone_field.dart
@@ -42,7 +42,10 @@ mixin AuthenticatorPhoneFieldMixin<
       .sortedBy((dialCode) => _dialCodeResolver.resolve(context, dialCode.key));
 
   String? formatPhoneNumber(String? phoneNumber) {
-    return phoneNumber?.ensureStartsWith('+${state.dialCode.value}');
+    if (phoneNumber == null || phoneNumber.isEmpty) {
+      return phoneNumber;
+    }
+    return phoneNumber.ensureStartsWith('+${state.dialCode.value}');
   }
 
   String displayPhoneNumber(String phoneNumber) {

--- a/packages/authenticator/amplify_authenticator/test/sign_up_form_test.dart
+++ b/packages/authenticator/amplify_authenticator/test/sign_up_form_test.dart
@@ -176,6 +176,35 @@ void main() {
         expect(usernameFieldError, findsOneWidget);
       });
 
+      testWidgets(
+        'displays message when required phone number submitted empty',
+        (tester) async {
+          await tester.pumpWidget(
+            MockAuthenticatorApp(
+              initialStep: AuthenticatorStep.signUp,
+              signUpForm: SignUpForm.custom(
+                fields: [
+                  SignUpFormField.username(),
+                  SignUpFormField.phoneNumber(required: true),
+                  SignUpFormField.password(),
+                  SignUpFormField.passwordConfirmation(),
+                ],
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          final signUpPage = SignUpPage(tester: tester);
+          await signUpPage.submitSignUp();
+
+          final phoneFieldError = find.descendant(
+            of: signUpPage.phoneField,
+            matching: find.text('Phone Number field must not be blank.'),
+          );
+          expect(phoneFieldError, findsOneWidget);
+        },
+      );
+
       testWidgets('displays message when password does not meet requirements', (
         tester,
       ) async {


### PR DESCRIPTION
## Description

A required phone number field (`SignUpFormField.phoneNumber(required: true)`) still accepted an empty value. `formatPhoneNumber` prepended the dial code to empty input (`"" -> "+1"`), so the value looked non-empty, passed validation, and the form submitted a bogus dial-code-only number instead of showing the required error. This leaves empty input untouched so the required/empty check runs.

## Screenshots

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/VarshithaPamisetty/amplify-flutter/pr-4079-assets/screenshots/before.png) | ![after](https://raw.githubusercontent.com/VarshithaPamisetty/amplify-flutter/pr-4079-assets/screenshots/after.png) |

Before: an empty required phone number passed validation and reached the `SignUp` call. After: it is blocked client-side with "Phone Number field must not be blank."

## Testing

- Added a widget test: a required phone field submitted empty now shows "Phone Number field must not be blank." (fails without the change).
- authenticator suite green: sign_up_form_test, form_field_controller_test, and 284 golden UI tests pass; dart analyze and dart format clean.
- Verified in the example app: empty required phone is now blocked client-side instead of reaching the SignUp call.

Fixes #4079
