### PR TITLE
test(kinesis): TEMP diagnose flaky flush

### DIFF
--- a/packages/kinesis/amplify_kinesis/example/integration_test/kinesis_integration_test.dart
+++ b/packages/kinesis/amplify_kinesis/example/integration_test/kinesis_integration_test.dart
@@ -15,6 +15,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'utils/setup_utils.dart';
 
 void main() {
+  AmplifyLogging.addSink(
+    AmplifySimplePrinterLogSink(logLevel: LogLevel.verbose),
+  );
   late AmplifyKinesisClient client;
   late AmplifyAuthCredentialsProvider credentialsProvider;
 
@@ -218,6 +221,7 @@ void main() {
       );
 
       final flushResult = await client.flush();
+      safePrint('DIAG kinesis flush result: $flushResult');
       expect(flushResult, isA<Ok<FlushData>>());
       expect((flushResult as Ok<FlushData>).value.recordsFlushed, equals(1));
 

--- a/packages/kinesis/amplify_kinesis_dart/lib/src/impl/kinesis_sender.dart
+++ b/packages/kinesis/amplify_kinesis_dart/lib/src/impl/kinesis_sender.dart
@@ -55,6 +55,15 @@ class KinesisSender implements Sender {
     // InternalFailure. All are treated as retryable until the retry
     // limit is reached.
     final errorCodes = response.records.map((e) => e.errorCode).toList();
+    // TEMP DIAG: surface the exact per-record errors behind flaky flushes.
+    final diagErrors = response.records
+        .where((e) => e.errorCode != null)
+        .map((e) => '${e.errorCode}: ${e.errorMessage}')
+        .toList();
+    if (diagErrors.isNotEmpty) {
+      // ignore: avoid_print
+      print('DIAG PutRecords $streamName per-record errors: $diagErrors');
+    }
     return splitResults(
       errorCodes: errorCodes,
       records: records,


### PR DESCRIPTION
Temporary: registers a verbose log sink + prints the flush result to capture the per-record PutRecords errorCode behind the intermittent `recordsFlushed=0`. Do not merge.