### PR TITLE
chore(kinesis): DIAG capture raw transport exception (do not merge)

### DIFF
--- a/packages/aws_common/lib/src/http/aws_http_client_io.dart
+++ b/packages/aws_common/lib/src/http/aws_http_client_io.dart
@@ -348,7 +348,11 @@ class AWSHttpClientImpl extends AWSHttpClient {
           }
         },
         onError: (Object error, StackTrace stackTrace) {
-          logger.debug('Error in stream: $error');
+          logger
+            ..debug('Error in stream: $error')
+            ..warn(
+              'TRANSPORT_DIAG (stream) type=${error.runtimeType} error=$error',
+            );
           if (!gotHeaders.isCompleted) {
             gotHeaders.completeError(
               AWSHttpException(request, error),
@@ -528,6 +532,7 @@ class AWSHttpClientImpl extends AWSHttpClient {
         ),
       );
     }).catchError((Object e, StackTrace st) {
+      _logger.warn('TRANSPORT_DIAG (send) type=${e.runtimeType} error=$e');
       completer.completeError(AWSHttpException(request, e), st);
     });
 

--- a/packages/kinesis/amplify_record_cache_dart/lib/src/client/record_client.dart
+++ b/packages/kinesis/amplify_record_cache_dart/lib/src/client/record_client.dart
@@ -8,6 +8,7 @@ import 'package:amplify_record_cache_dart/src/model/record_data.dart';
 import 'package:amplify_record_cache_dart/src/model/record_input.dart';
 import 'package:amplify_record_cache_dart/src/sender/sender.dart';
 import 'package:amplify_record_cache_dart/src/storage/record_storage.dart';
+import 'package:aws_common/aws_common.dart' show AWSHttpException;
 import 'package:meta/meta.dart';
 import 'package:smithy/smithy.dart'
     show SmithyHttpException, UnknownSmithyHttpException;
@@ -106,7 +107,18 @@ class RecordClient {
           );
           await _handleFailedRequest(records);
         } catch (e) {
-          _logger.warn('Error flushing stream $streamName: $e. Aborting flush');
+          final underlying = e is AWSHttpException
+              ? e.underlyingException
+              : null;
+          _logger
+            ..warn(
+              'FLUSH_DIAG stream=$streamName '
+              'type=${e.runtimeType} '
+              'isAWSHttpException=${e is AWSHttpException} '
+              'underlyingType=${underlying?.runtimeType ?? 'n/a'} '
+              'underlying=$underlying',
+            )
+            ..warn('Error flushing stream $streamName: $e. Aborting flush');
           await _handleFailedRequest(records);
           rethrow;
         }


### PR DESCRIPTION
Temporary diagnostic off main (no retry fix) to capture the exact underlying exception when a Kinesis flush aborts. Logs FLUSH_DIAG at the flush catch. For investigation only — do not merge.