### PR TITLE
fix(api): support explicit realtime endpoint for custom domains

### DIFF
--- a/packages/amplify_core/lib/src/config/amplify_outputs/api_outputs.dart
+++ b/packages/amplify_core/lib/src/config/amplify_outputs/api_outputs.dart
@@ -9,6 +9,9 @@ import 'package:amplify_core/amplify_core.dart';
 abstract interface class ApiOutputs {
   String get awsRegion;
   String get url;
+
+  /// Explicit real-time (WebSocket) endpoint, used verbatim when set.
+  String? get realtimeUrl;
   String? get apiKey;
   APIAuthorizationType get authorizationType;
   ApiType get apiType;

--- a/packages/amplify_core/lib/src/config/amplify_outputs/data/data_outputs.dart
+++ b/packages/amplify_core/lib/src/config/amplify_outputs/data/data_outputs.dart
@@ -17,6 +17,7 @@ class DataOutputs
   const DataOutputs({
     required this.awsRegion,
     required this.url,
+    this.realtimeUrl,
     this.apiKey,
     required this.defaultAuthorizationType,
     required this.authorizationTypes,
@@ -32,6 +33,11 @@ class DataOutputs
   /// The AppSync endpoint URL.
   @override
   final String url;
+
+  /// Explicit real-time (WebSocket) endpoint. Use for custom domains where the
+  /// real-time host cannot be derived from [url] (e.g. CloudFront in front of AppSync).
+  @override
+  final String? realtimeUrl;
 
   /// The AppSync API Key.
   @override
@@ -56,6 +62,7 @@ class DataOutputs
   List<Object?> get props => [
     awsRegion,
     url,
+    realtimeUrl,
     apiKey,
     defaultAuthorizationType,
     authorizationTypes,

--- a/packages/amplify_core/lib/src/config/amplify_outputs/data/data_outputs.g.dart
+++ b/packages/amplify_core/lib/src/config/amplify_outputs/data/data_outputs.g.dart
@@ -15,6 +15,7 @@ DataOutputs _$DataOutputsFromJson(Map<String, dynamic> json) => $checkedCreate(
     final val = DataOutputs(
       awsRegion: $checkedConvert('aws_region', (v) => v as String),
       url: $checkedConvert('url', (v) => v as String),
+      realtimeUrl: $checkedConvert('realtime_url', (v) => v as String?),
       apiKey: $checkedConvert('api_key', (v) => v as String?),
       defaultAuthorizationType: $checkedConvert(
         'default_authorization_type',
@@ -31,6 +32,7 @@ DataOutputs _$DataOutputsFromJson(Map<String, dynamic> json) => $checkedCreate(
   },
   fieldKeyMap: const {
     'awsRegion': 'aws_region',
+    'realtimeUrl': 'realtime_url',
     'apiKey': 'api_key',
     'defaultAuthorizationType': 'default_authorization_type',
     'authorizationTypes': 'authorization_types',
@@ -41,6 +43,7 @@ Map<String, dynamic> _$DataOutputsToJson(DataOutputs instance) =>
     <String, dynamic>{
       'aws_region': instance.awsRegion,
       'url': instance.url,
+      'realtime_url': ?instance.realtimeUrl,
       'api_key': ?instance.apiKey,
       'default_authorization_type':
           _$APIAuthorizationTypeEnumMap[instance.defaultAuthorizationType]!,

--- a/packages/amplify_core/lib/src/config/amplify_outputs/rest_api/rest_api_outputs.dart
+++ b/packages/amplify_core/lib/src/config/amplify_outputs/rest_api/rest_api_outputs.dart
@@ -35,6 +35,10 @@ class RestApiOutputs
   @override
   final String url;
 
+  /// REST APIs have no real-time endpoint.
+  @override
+  String? get realtimeUrl => null;
+
   /// The Amazon API Gateway API Key.
   @override
   final String? apiKey;

--- a/packages/api/amplify_api_dart/lib/src/decorators/web_socket_auth_utils.dart
+++ b/packages/api/amplify_api_dart/lib/src/decorators/web_socket_auth_utils.dart
@@ -39,18 +39,16 @@ Future<Uri> generateConnectionUri(ApiOutputs config) async {
   final authQueryParameters = {
     'payload': base64.encode(utf8.encode(json.encode(appSyncDefaultPayload))),
   };
-  // Use an explicitly configured real-time endpoint verbatim when provided.
-  // Required for custom domains (e.g. CloudFront) where the real-time host
-  // cannot be derived from the HTTP endpoint. See amplify-flutter#6877.
+  // Explicitly configured realtime endpoint (e.g. custom domain, see
+  // amplify-flutter#6877): normalize scheme to wss, keep any customer-set
+  // query params, and append the payload auth param (payload overrides).
   final realtimeUrl = config.realtimeUrl;
   if (realtimeUrl != null) {
     final uri = Uri.parse(realtimeUrl);
-    return Uri(
+    return uri.replace(
       scheme: 'wss',
-      host: uri.host,
-      port: uri.hasPort ? uri.port : null,
-      path: uri.path,
-    ).replace(queryParameters: authQueryParameters);
+      queryParameters: {...uri.queryParameters, ...authQueryParameters},
+    );
   }
   // Conditionally format the URI for a) AppSync domain b) custom domain.
   var endpointUriHost = Uri.parse(config.url).host;

--- a/packages/api/amplify_api_dart/lib/src/decorators/web_socket_auth_utils.dart
+++ b/packages/api/amplify_api_dart/lib/src/decorators/web_socket_auth_utils.dart
@@ -39,6 +39,19 @@ Future<Uri> generateConnectionUri(ApiOutputs config) async {
   final authQueryParameters = {
     'payload': base64.encode(utf8.encode(json.encode(appSyncDefaultPayload))),
   };
+  // Use an explicitly configured real-time endpoint verbatim when provided.
+  // Required for custom domains (e.g. CloudFront) where the real-time host
+  // cannot be derived from the HTTP endpoint. See amplify-flutter#6877.
+  final realtimeUrl = config.realtimeUrl;
+  if (realtimeUrl != null) {
+    final uri = Uri.parse(realtimeUrl);
+    return Uri(
+      scheme: 'wss',
+      host: uri.host,
+      port: uri.hasPort ? uri.port : null,
+      path: uri.path,
+    ).replace(queryParameters: authQueryParameters);
+  }
   // Conditionally format the URI for a) AppSync domain b) custom domain.
   var endpointUriHost = Uri.parse(config.url).host;
   String path;
@@ -111,14 +124,25 @@ Future<Map<String, String>> generateAuthorizationHeaders(
   APIAuthorizationType? authorizationMode,
   Map<String, String>? customHeaders,
 }) async {
-  final endpointHost = Uri.parse(config.url).host;
+  // AppSync requires the "host" attribute in the WebSocket payload to be the
+  // AppSync (appsync-api) domain. When an explicit realtimeUrl is configured
+  // (e.g. custom domain), derive it from that endpoint instead of config.url.
+  final realtimeUrl = config.realtimeUrl;
+  final authUrl = realtimeUrl != null
+      ? Uri.parse(config.url).replace(
+          host: Uri.parse(
+            realtimeUrl,
+          ).host.replaceFirst(_appSyncRealtimeHostPortion, _appSyncHostPortion),
+        )
+      : Uri.parse(config.url);
+  final endpointHost = authUrl.host;
   // Create canonical HTTP request to authorize but never send.
   //
   // The canonical request URL is a little different depending on if authorizing
   // connection URI or start message (subscription registration).
   final maybeConnect = isConnectionInit ? '/connect' : '';
   final canonicalHttpRequest = AWSStreamedHttpRequest.post(
-    Uri.parse('${config.url}$maybeConnect'),
+    Uri.parse('$authUrl$maybeConnect'),
     headers: {...?customHeaders, ..._requiredHeaders},
     body: HttpPayload.json(body),
   );

--- a/packages/api/amplify_api_dart/test/util.dart
+++ b/packages/api/amplify_api_dart/test/util.dart
@@ -100,6 +100,28 @@ const testConfigWithRealtimeUrl = DataOutputs(
 const expectedRealtimeUrlWebSocketConnectionUrl =
     'wss://abc123.appsync-realtime-api.us-east-1.amazonaws.com/graphql?payload=e30%3D';
 
+// realtimeUrl configured with an https:// scheme (should normalize to wss).
+const testConfigWithHttpsRealtimeUrl = DataOutputs(
+  url: 'https://custom.example.com/graphql',
+  realtimeUrl:
+      'https://abc123.appsync-realtime-api.us-east-1.amazonaws.com/graphql',
+  awsRegion: 'us-east-1',
+  defaultAuthorizationType: APIAuthorizationType.apiKey,
+  apiKey: 'abc-123',
+  authorizationTypes: [APIAuthorizationType.apiKey],
+);
+
+// realtimeUrl configured with customer-set query params (must be preserved).
+const testConfigWithRealtimeUrlQueryParams = DataOutputs(
+  url: 'https://custom.example.com/graphql',
+  realtimeUrl:
+      'wss://abc123.appsync-realtime-api.us-east-1.amazonaws.com/graphql?foo=bar&baz=qux',
+  awsRegion: 'us-east-1',
+  defaultAuthorizationType: APIAuthorizationType.apiKey,
+  apiKey: 'abc-123',
+  authorizationTypes: [APIAuthorizationType.apiKey],
+);
+
 AmplifyAuthProviderRepository getTestAuthProviderRepo() {
   final testAuthProviderRepo = AmplifyAuthProviderRepository()
     ..registerAuthProvider(

--- a/packages/api/amplify_api_dart/test/util.dart
+++ b/packages/api/amplify_api_dart/test/util.dart
@@ -87,6 +87,19 @@ const expectedApiKeyWebSocketConnectionUrl =
 const expectedApiKeyWebSocketConnectionUrlCustomDomain =
     'wss://foo.bar.aws.dev/graphql/realtime?payload=e30%3D';
 
+// Custom domain (e.g. CloudFront) with an explicit real-time endpoint (#6877).
+const testConfigWithRealtimeUrl = DataOutputs(
+  url: 'https://custom.example.com/graphql',
+  realtimeUrl:
+      'wss://abc123.appsync-realtime-api.us-east-1.amazonaws.com/graphql',
+  awsRegion: 'us-east-1',
+  defaultAuthorizationType: APIAuthorizationType.apiKey,
+  apiKey: 'abc-123',
+  authorizationTypes: [APIAuthorizationType.apiKey],
+);
+const expectedRealtimeUrlWebSocketConnectionUrl =
+    'wss://abc123.appsync-realtime-api.us-east-1.amazonaws.com/graphql?payload=e30%3D';
+
 AmplifyAuthProviderRepository getTestAuthProviderRepo() {
   final testAuthProviderRepo = AmplifyAuthProviderRepository()
     ..registerAuthProvider(

--- a/packages/api/amplify_api_dart/test/web_socket/web_socket_auth_utils_test.dart
+++ b/packages/api/amplify_api_dart/test/web_socket/web_socket_auth_utils_test.dart
@@ -64,6 +64,16 @@ void main() {
         expectedApiKeyWebSocketConnectionUrlCustomDomain,
       );
     });
+
+    test('should use an explicit realtimeUrl when configured', () async {
+      final actualConnectionUri = await generateConnectionUri(
+        testConfigWithRealtimeUrl,
+      );
+      expect(
+        actualConnectionUri.toString(),
+        expectedRealtimeUrlWebSocketConnectionUrl,
+      );
+    });
   });
 
   group('generateSubscriptionRegistrationMessage', () {
@@ -152,6 +162,21 @@ void main() {
       expect(headers.containsKey(AWSHeaders.contentEncoding), true);
       expect(headers.containsKey(AWSHeaders.contentType), true);
       expect(headers.containsKey(AWSHeaders.host), true);
+    });
+
+    test('should use realtime-derived host when realtimeUrl is configured',
+        () async {
+      final headers = await generateAuthorizationHeaders(
+        testConfigWithRealtimeUrl,
+        isConnectionInit: true,
+        authRepo: authProviderRepo,
+        body: {},
+      );
+      // Host must be the appsync-api domain, not the realtime or custom domain.
+      expect(
+        headers[AWSHeaders.host],
+        'abc123.appsync-api.us-east-1.amazonaws.com',
+      );
     });
 
     test('should generate headers for IAM Authorization', () async {

--- a/packages/api/amplify_api_dart/test/web_socket/web_socket_auth_utils_test.dart
+++ b/packages/api/amplify_api_dart/test/web_socket/web_socket_auth_utils_test.dart
@@ -74,6 +74,31 @@ void main() {
         expectedRealtimeUrlWebSocketConnectionUrl,
       );
     });
+
+    test('should normalize an https realtimeUrl scheme to wss', () async {
+      final actualConnectionUri = await generateConnectionUri(
+        testConfigWithHttpsRealtimeUrl,
+      );
+      expect(actualConnectionUri.scheme, 'wss');
+      expect(
+        actualConnectionUri.toString(),
+        expectedRealtimeUrlWebSocketConnectionUrl,
+      );
+    });
+
+    test('should preserve realtimeUrl query params and append payload',
+        () async {
+      final actualConnectionUri = await generateConnectionUri(
+        testConfigWithRealtimeUrlQueryParams,
+      );
+      final params = actualConnectionUri.queryParameters;
+      // Customer-set query params are preserved...
+      expect(params['foo'], 'bar');
+      expect(params['baz'], 'qux');
+      // ...and the payload auth param is appended.
+      expect(params['payload'], 'e30=');
+      expect(actualConnectionUri.scheme, 'wss');
+    });
   });
 
   group('generateSubscriptionRegistrationMessage', () {


### PR DESCRIPTION
Fixes #6877. Related: #3028.

## Problem
The realtime WebSocket URL is derived by appending `/realtime` to any non-`appsync-api`
host. That only works for AppSync *native* custom domains. Behind a proxy (e.g.
CloudFront), `wss://<domain>/graphql/realtime` doesn't exist → handshake 404s while
HTTP GraphQL works. amplify-js derives the realtime URL the same way and shares this
limitation; this PR adds an explicit override.

## Fix
New optional `realtime_url` in the data config (`ApiOutputs.realtimeUrl`). When set,
it's used for the WebSocket: scheme normalized to `wss` (https accepted), customer
query params preserved, payload auth param appended; the auth payload `host` derives
the `appsync-api` host from it. When absent: behavior unchanged.

```json
"data": {
  "url": "https://your-domain.example.com/graphql",
  "realtime_url": "wss://<api-id>.appsync-realtime-api.<region>.amazonaws.com/graphql"
}
```

## Verification
- Unit: 13/13 `web_socket_auth_utils_test.dart` (5 new: URI, derived host, https
  normalization, query param preservation); `amplify_core` config 45/45.
- Live e2e (Flutter web, CloudFront-fronted AppSync, Cognito User Pools): subscription
  establishes on the configured realtime host and delivers events; pre-fix 404 gone.

## Notes
- `realtime_url` is a manual addition to `amplify_outputs` (not yet emitted by backend
  tooling).
- Follow-up: document `realtime_url` in aws-amplify/docs (custom domain / connect to
  existing API pages).
- Live-tested on web with Cognito User Pools; other platforms share the code path,
  other auth modes not live-tested.
