### PR TITLE
fix(auth): handle user_cancelled_authorize in Hosted UI redirects

### DIFF
--- a/packages/auth/amplify_auth_cognito/test/hosted_ui_platform_flutter_test.dart
+++ b/packages/auth/amplify_auth_cognito/test/hosted_ui_platform_flutter_test.dart
@@ -73,7 +73,59 @@ void main() {
       // signInWithWebUI completes.
       await hostedUiMachine.close();
     });
+
+    // The native platform returns the query parameters of the redirect URI,
+    // which include an error code when the user cancels at the identity
+    // provider, e.g. at the Sign in with Apple consent screen.
+    //
+    // https://github.com/aws-amplify/amplify-flutter/issues/7077
+    test('can cancel flow at the identity provider', () async {
+      dependencyManager.addInstance<NativeAuthBridge>(CancellingNativeBridge());
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+      final expectation = expectLater(
+        plugin.signInWithWebUI(provider: AuthProvider.apple),
+        throwsA(isA<UserCancelledException>()),
+      );
+      final hostedUiMachine = plugin.stateMachine.expect(
+        HostedUiStateMachine.type,
+      );
+      expect(
+        hostedUiMachine.stream,
+        emitsInOrder([
+          isA<HostedUiSigningIn>(),
+          // Emitted again for the exchange event.
+          emitsThrough(
+            isA<HostedUiFailure>().having(
+              (s) => s.exception,
+              'exception',
+              isA<UserCancelledException>(),
+            ),
+          ),
+          emitsDone,
+        ]),
+      );
+      await expectation;
+      await hostedUiMachine.close();
+    });
   });
+}
+
+final class CancellingNativeBridge extends Fake implements NativeAuthBridge {
+  @override
+  Future<Map<String, String>> signInWithUrl(
+    String arg_url,
+    String arg_callbackUrlScheme,
+    bool arg_preferPrivateSession,
+    String? arg_browserPackageName,
+  ) async => const {
+    'error_description':
+        'Error response from Identity Provider; '
+        'error=user_cancelled_authorize',
+    'state': 'STATE',
+    'error': 'user_cancelled_authorize',
+  };
 }
 
 final class ThrowingNativeBridge extends Fake implements NativeAuthBridge {

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/auth_plugin_impl.dart
@@ -186,6 +186,13 @@ class AmplifyAuthCognitoDart extends AuthPluginInterface
           _hubEventController.add(hubEvent);
         }
       },
+      // State machine errors which cannot be resolved to a state are reported
+      // to the caller of the API which triggered them, via the stream of the
+      // state machine itself. Handle them here as well so that they are not
+      // re-raised as uncaught async errors in the app's zone.
+      onError: (Object error, StackTrace stackTrace) {
+        logger.verbose('Unresolved state machine error', error, stackTrace);
+      },
       cancelOnError: false,
       onDone: _hubEventController.close,
     );

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/flows/hosted_ui/hosted_ui_platform.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/flows/hosted_ui/hosted_ui_platform.dart
@@ -227,6 +227,15 @@ abstract class HostedUiPlatform implements Closeable {
         throw LambdaException(errorDesc);
       }
 
+      // The user cancelled the flow at the identity provider, e.g. by
+      // declining the consent screen shown by Sign in with Apple. Amazon
+      // Cognito relays the provider's error code verbatim.
+      if (error == OAuthErrorCode.userCancelledAuthorize) {
+        throw const UserCancelledException(
+          'The user cancelled the sign-in flow',
+        );
+      }
+
       final errorUri = parameters.errorUri;
       final desc = StringBuffer(errorDesc);
       if (errorUri != null) {

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/hosted_ui/oauth_parameters.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/hosted_ui/oauth_parameters.dart
@@ -121,6 +121,22 @@ class OAuthErrorCode extends EnumClass {
   static const OAuthErrorCode registrationUriNotSupported =
       _$registrationUriNotSupported;
 
+  /// The user cancelled the authorization request at the identity provider,
+  /// e.g. by declining the consent screen shown by Sign in with Apple.
+  ///
+  /// This code is not part of the OAuth or OIDC specifications. It is relayed
+  /// verbatim by Amazon Cognito from the external identity provider.
+  @BuiltValueEnumConst(wireName: 'user_cancelled_authorize')
+  static const OAuthErrorCode userCancelledAuthorize = _$userCancelledAuthorize;
+
+  /// An error code which is not recognized by this library.
+  ///
+  /// Amazon Cognito relays error codes from external identity providers
+  /// verbatim, so the set of codes which may be returned is open-ended.
+  /// Unrecognized codes deserialize to this value instead of failing.
+  @BuiltValueEnumConst(wireName: 'unknown')
+  static const OAuthErrorCode unknown = _$unknown;
+
   /// The user-facing description of the error.
   String get description {
     switch (this) {
@@ -145,6 +161,8 @@ class OAuthErrorCode extends EnumClass {
       case OAuthErrorCode.unsupportedResponseType:
         return 'The authorization server does not support obtaining an '
             'authorization code using this method.';
+      case OAuthErrorCode.userCancelledAuthorize:
+        return 'The user cancelled the sign-in flow.';
       case OAuthErrorCode.accountSelectionRequired:
       case OAuthErrorCode.consentRequired:
       case OAuthErrorCode.interactionRequired:
@@ -154,6 +172,7 @@ class OAuthErrorCode extends EnumClass {
       case OAuthErrorCode.registrationUriNotSupported:
       case OAuthErrorCode.requestNotSupported:
       case OAuthErrorCode.requestUriNotSupported:
+      case OAuthErrorCode.unknown:
         return 'An unknown error occurred.';
     }
     throw ArgumentError('Invalid code: $this');
@@ -166,8 +185,59 @@ class OAuthErrorCode extends EnumClass {
   static OAuthErrorCode valueOf(String name) => _$valueOf(name);
 
   /// The [OAuthErrorCode] serializer.
+  ///
+  /// Note: [oauthSerializers] overrides this with
+  /// [_OAuthErrorCodeSerializer], which tolerates unrecognized error codes.
   static Serializer<OAuthErrorCode> get serializer =>
       _$oAuthErrorCodeSerializer;
+}
+
+/// {@template amplify_auth_cognito.oauth_error_code_serializer}
+/// Serializer for [OAuthErrorCode] which deserializes unrecognized error codes
+/// to [OAuthErrorCode.unknown] instead of throwing.
+///
+/// Amazon Cognito relays error codes from external identity providers verbatim,
+/// e.g. `user_cancelled_authorize` from Sign in with Apple, so the set of codes
+/// which may be received is open-ended. Failing to deserialize them would
+/// surface as an unrecoverable error instead of an [AuthException].
+/// {@endtemplate}
+class _OAuthErrorCodeSerializer implements PrimitiveSerializer<OAuthErrorCode> {
+  /// {@macro amplify_auth_cognito.oauth_error_code_serializer}
+  const _OAuthErrorCodeSerializer();
+
+  /// The generated serializer, which throws for unrecognized codes.
+  static PrimitiveSerializer<OAuthErrorCode> get _generated =>
+      _$oAuthErrorCodeSerializer as PrimitiveSerializer<OAuthErrorCode>;
+
+  @override
+  Iterable<Type> get types => const [OAuthErrorCode];
+
+  @override
+  String get wireName => 'OAuthErrorCode';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    OAuthErrorCode object, {
+    FullType specifiedType = FullType.unspecified,
+  }) => _generated.serialize(serializers, object, specifiedType: specifiedType);
+
+  @override
+  OAuthErrorCode deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    try {
+      return _generated.deserialize(
+        serializers,
+        serialized,
+        specifiedType: specifiedType,
+      );
+    } on ArgumentError {
+      return OAuthErrorCode.unknown;
+    }
+  }
 }
 
 /// {@template amplify_auth_cognito.oauth_parameters}
@@ -191,8 +261,20 @@ abstract class OAuthParameters
         value is String ? Uri.decodeQueryComponent(value) : '',
       );
     });
-    return oauthSerializers.deserializeWith(serializer, json)
-        as OAuthParameters;
+    final parameters =
+        oauthSerializers.deserializeWith(serializer, json) as OAuthParameters;
+
+    // Unrecognized error codes are deserialized as [OAuthErrorCode.unknown].
+    // Retain the raw code so that it is not lost when no description was
+    // provided by the authorization server.
+    final rawError = json['error'];
+    if (parameters.error == OAuthErrorCode.unknown &&
+        parameters.errorDescription == null &&
+        rawError is String) {
+      return parameters.rebuild((b) => b.errorDescription = rawError);
+    }
+
+    return parameters;
   }
 
   /// Parses OAuth parameters from a [uri].
@@ -274,4 +356,9 @@ abstract class OAuthParameters
 /// Serializers for OAuth flow parameters.
 @SerializersFor([OAuthErrorCode, OAuthParameters])
 final Serializers oauthSerializers =
-    (_$oauthSerializers.toBuilder()..addPlugin(StandardJsonPlugin())).build();
+    (_$oauthSerializers.toBuilder()
+          ..addPlugin(StandardJsonPlugin())
+          // Overrides the generated [OAuthErrorCode] serializer, which throws
+          // for unrecognized error codes.
+          ..add(const _OAuthErrorCodeSerializer()))
+        .build();

--- a/packages/auth/amplify_auth_cognito_dart/lib/src/model/hosted_ui/oauth_parameters.g.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/model/hosted_ui/oauth_parameters.g.dart
@@ -46,6 +46,10 @@ const OAuthErrorCode _$requestUriNotSupported = const OAuthErrorCode._(
 const OAuthErrorCode _$registrationUriNotSupported = const OAuthErrorCode._(
   'registrationUriNotSupported',
 );
+const OAuthErrorCode _$userCancelledAuthorize = const OAuthErrorCode._(
+  'userCancelledAuthorize',
+);
+const OAuthErrorCode _$unknown = const OAuthErrorCode._('unknown');
 
 OAuthErrorCode _$valueOf(String name) {
   switch (name) {
@@ -81,6 +85,10 @@ OAuthErrorCode _$valueOf(String name) {
       return _$requestUriNotSupported;
     case 'registrationUriNotSupported':
       return _$registrationUriNotSupported;
+    case 'userCancelledAuthorize':
+      return _$userCancelledAuthorize;
+    case 'unknown':
+      return _$unknown;
     default:
       throw ArgumentError(name);
   }
@@ -104,6 +112,8 @@ final BuiltSet<OAuthErrorCode> _$values =
       _$requestNotSupported,
       _$requestUriNotSupported,
       _$registrationUriNotSupported,
+      _$userCancelledAuthorize,
+      _$unknown,
     ]);
 
 Serializers _$oauthSerializers =
@@ -135,6 +145,8 @@ class _$OAuthErrorCodeSerializer
     'requestNotSupported': 'request_not_supported',
     'requestUriNotSupported': 'request_uri_not_supported',
     'registrationUriNotSupported': 'registration_uri_not_supported',
+    'userCancelledAuthorize': 'user_cancelled_authorize',
+    'unknown': 'unknown',
   };
   static const Map<Object, String> _fromWire = const <Object, String>{
     'invalid_request': 'invalidRequest',
@@ -153,6 +165,8 @@ class _$OAuthErrorCodeSerializer
     'request_not_supported': 'requestNotSupported',
     'request_uri_not_supported': 'requestUriNotSupported',
     'registration_uri_not_supported': 'registrationUriNotSupported',
+    'user_cancelled_authorize': 'userCancelledAuthorize',
+    'unknown': 'unknown',
   };
 
   @override

--- a/packages/auth/amplify_auth_cognito_test/test/flows/hostedui/hosted_ui_platform_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/flows/hostedui/hosted_ui_platform_test.dart
@@ -11,6 +11,7 @@ import 'package:amplify_auth_cognito_dart/src/state/cognito_state_machine.dart';
 import 'package:amplify_auth_cognito_dart/src/state/state.dart';
 import 'package:amplify_auth_cognito_test/common/mock_config.dart';
 import 'package:amplify_auth_cognito_test/common/mock_dispatcher.dart';
+import 'package:amplify_auth_cognito_test/common/mock_hosted_ui.dart';
 import 'package:amplify_auth_cognito_test/common/mock_oauth_server.dart';
 import 'package:amplify_auth_cognito_test/common/mock_secure_storage.dart';
 import 'package:amplify_core/amplify_core.dart';
@@ -112,6 +113,43 @@ void main() {
 
         expect(platform.exchange(parameters), completes);
       });
+
+      // https://github.com/aws-amplify/amplify-flutter/issues/7077
+      test('user_cancelled_authorize throws UserCancelledException', () {
+        expect(
+          platform.exchange(
+            OAuthParameters(
+              (b) => b
+                ..state = state
+                ..error = OAuthErrorCode.userCancelledAuthorize
+                ..errorDescription =
+                    'Error response from Identity Provider; '
+                    'error=user_cancelled_authorize',
+            ),
+          ),
+          throwsA(isA<UserCancelledException>()),
+        );
+      });
+
+      test('unrecognized error codes throw UnknownException', () {
+        expect(
+          platform.exchange(
+            OAuthParameters(
+              (b) => b
+                ..state = state
+                ..error = OAuthErrorCode.unknown
+                ..errorDescription = 'some_provider_specific_error',
+            ),
+          ),
+          throwsA(
+            isA<UnknownException>().having(
+              (e) => e.message,
+              'message',
+              contains('some_provider_specific_error'),
+            ),
+          ),
+        );
+      });
     });
 
     group('signIn', () {
@@ -156,6 +194,84 @@ void main() {
         // Ensure queue is flushed and done event is emitted after
         // signInWithWebUI completes.
         await hostedUiMachine.close();
+      });
+    });
+
+    // The identity provider can redirect back with an error code instead of an
+    // authorization code, e.g. when the user cancels at the provider's consent
+    // screen. The error must be delivered to the caller of `signInWithWebUI`
+    // and must not be re-raised as an uncaught async error.
+    //
+    // https://github.com/aws-amplify/amplify-flutter/issues/7077
+    group('cancelled at the identity provider', () {
+      const cancelUri =
+          'myapp://callback'
+          '?error_description=Error+response+from+Identity+Provider;'
+          '+error=user_cancelled_authorize'
+          '&state=STATE'
+          '&error=user_cancelled_authorize';
+
+      late AmplifyAuthCognitoDart plugin;
+
+      setUp(() async {
+        final secureStorage = MockSecureStorage();
+        SecureStorageInterface storageFactory(scope) => secureStorage;
+        final stateMachine = CognitoAuthStateMachine()
+          ..addInstance<SecureStorageInterface>(secureStorage)
+          ..addInstance<http.Client>(server.httpClient);
+        stateMachine.addBuilder<HostedUiPlatform>(
+          createHostedUiFactory(
+            // Mimics the native platform returning the error parameters of
+            // the redirect URI.
+            signIn: (platform, options, provider) async {
+              stateMachine
+                  .dispatch(
+                    HostedUiEvent.exchange(
+                      OAuthParameters.fromUri(Uri.parse(cancelUri))!,
+                    ),
+                  )
+                  .ignore();
+            },
+            signOut: (platform, options) async {},
+          ),
+        );
+        plugin = AmplifyAuthCognitoDart(secureStorageFactory: storageFactory)
+          ..stateMachine = stateMachine;
+        // `configure` installs the plugin's listener on the state machine,
+        // which is where unresolved errors would otherwise become uncaught.
+        await plugin.configure(
+          config: mockConfig,
+          authProviderRepo: AmplifyAuthProviderRepository(),
+        );
+      });
+
+      tearDown(() => plugin.close());
+
+      test('throws UserCancelledException without an uncaught async '
+          'error', () async {
+        final uncaughtErrors = <Object>[];
+        final testCompleted = Completer<void>();
+
+        unawaited(
+          runZonedGuarded(
+            () async {
+              await expectLater(
+                plugin.signInWithWebUI(provider: AuthProvider.apple),
+                throwsA(isA<UserCancelledException>()),
+              );
+              // Allow any uncaught error to propagate to the zone handler.
+              await Future<void>.delayed(Duration.zero);
+              testCompleted.complete();
+            },
+            (error, stackTrace) {
+              uncaughtErrors.add(error);
+              if (!testCompleted.isCompleted) testCompleted.complete();
+            },
+          ),
+        );
+
+        await testCompleted.future;
+        expect(uncaughtErrors, isEmpty);
       });
     });
   });

--- a/packages/auth/amplify_auth_cognito_test/test/flows/hostedui/oauth_parameters_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/flows/hostedui/oauth_parameters_test.dart
@@ -1,0 +1,93 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:amplify_auth_cognito_dart/src/model/hosted_ui/oauth_parameters.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('OAuthParameters', () {
+    group('fromUri', () {
+      test('parses an authorization code redirect', () {
+        final parameters = OAuthParameters.fromUri(
+          Uri.parse('myapp://callback?code=CODE&state=STATE'),
+        );
+        expect(parameters, isNotNull);
+        expect(parameters!.code, 'CODE');
+        expect(parameters.state, 'STATE');
+        expect(parameters.error, isNull);
+      });
+
+      test('parses a standard OAuth error redirect', () {
+        final parameters = OAuthParameters.fromUri(
+          Uri.parse('myapp://callback?error=access_denied&state=STATE'),
+        );
+        expect(parameters, isNotNull);
+        expect(parameters!.error, OAuthErrorCode.accessDenied);
+      });
+
+      // Cancelling at the identity provider's consent screen, e.g. Sign in
+      // with Apple, results in an error code which is not part of the OAuth or
+      // OIDC specifications.
+      //
+      // https://github.com/aws-amplify/amplify-flutter/issues/7077
+      test('parses user_cancelled_authorize', () {
+        final parameters = OAuthParameters.fromUri(
+          Uri.parse(
+            'myapp://callback'
+            '?error_description=Error+response+from+Identity+Provider;'
+            '+error=user_cancelled_authorize'
+            '&state=STATE'
+            '&error=user_cancelled_authorize',
+          ),
+        );
+        expect(parameters, isNotNull);
+        expect(parameters!.error, OAuthErrorCode.userCancelledAuthorize);
+        expect(parameters.state, 'STATE');
+        expect(
+          parameters.errorDescription,
+          'Error response from Identity Provider; '
+          'error=user_cancelled_authorize',
+        );
+      });
+
+      test('parses unrecognized error codes as unknown', () {
+        final parameters = OAuthParameters.fromUri(
+          Uri.parse(
+            'myapp://callback'
+            '?error=some_provider_specific_error'
+            '&error_description=Something+went+wrong'
+            '&state=STATE',
+          ),
+        );
+        expect(parameters, isNotNull);
+        expect(parameters!.error, OAuthErrorCode.unknown);
+        expect(parameters.errorDescription, 'Something went wrong');
+      });
+
+      test('retains unrecognized error codes without a description', () {
+        final parameters = OAuthParameters.fromUri(
+          Uri.parse(
+            'myapp://callback'
+            '?error=some_provider_specific_error'
+            '&state=STATE',
+          ),
+        );
+        expect(parameters, isNotNull);
+        expect(parameters!.error, OAuthErrorCode.unknown);
+        expect(parameters.errorDescription, 'some_provider_specific_error');
+      });
+
+      test('returns null for a non-redirect URI', () {
+        expect(OAuthParameters.fromUri(Uri.parse('myapp://callback')), isNull);
+      });
+    });
+
+    group('description', () {
+      test('is defined for all error codes', () {
+        for (final code in OAuthErrorCode.values) {
+          expect(() => code.description, returnsNormally, reason: '$code');
+        }
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Description

Cancelling Hosted UI sign-in at an external identity provider (for example the Sign in with Apple consent screen) redirects back with `error=user_cancelled_authorize`. Two defects follow from that.

1. `OAuthErrorCode` had no such value, so `OAuthParameters.fromJson` threw a built_value `DeserializationError` instead of producing a `UserCancelledException`.

2. `DeserializationError` extends `Error`, not `Exception`, so `HostedUiStateMachine.resolveError` could not resolve it to a `HostedUiFailure` state. `_emitError` then added the unresolved error to the plugin's state stream, whose subscription registered no `onError` handler, and it surfaced as an uncaught async error that escaped the caller's try/catch around `signInWithWebUI`.

Changes:

- Add `OAuthErrorCode.userCancelledAuthorize` and map it to `UserCancelledException` in `HostedUiPlatform.exchange`.
- Deserialize unrecognized error codes as `OAuthErrorCode.unknown` instead of throwing. Cognito relays error codes from external identity providers verbatim, so the set of possible values is open ended. The raw code is kept in `errorDescription` when the authorization server sends no description. This also matters on web, where `initialParameters` is a top level `final` evaluated at import, so a throw there breaks plugin load.
- Handle errors on the plugin's state machine subscription so unresolved errors are not re-raised as uncaught async errors. They still reach the caller through the state machine's own stream.

## Testing

- New `oauth_parameters_test.dart`: the callback URI from the issue, standard OAuth codes, unknown code fallback, raw code retention.
- `exchange` mapping tests for `userCancelledAuthorize` and for unknown codes.
- End to end test through `plugin.configure()` asserting `UserCancelledException` and zero uncaught errors via `runZonedGuarded`.
- Flutter level test with a fake native bridge returning the Android query parameter map. It fails without this change with the reported deserialization error.
- `amplify_auth_cognito_test` 316, `amplify_auth_cognito_dart` 7 (including `ensure_build_test`), `amplify_core` 156, `amplify_auth_cognito` 2. All pass. `analyze` and `format` clean on Flutter 3.47.1 / Dart 3.13.1.

## Notes

Deliberately out of scope:

- `access_denied` still maps to `UnknownException`. Cognito returns it both when a user declines on its own consent screen and for genuine authorization server denials, so remapping it to `UserCancelledException` is a behavior change beyond this fix. Tracked in #7351.
- `HostedUiStateMachine.resolveError` still returns `null` for `Error`s. Programming errors should not be converted into a `HostedUiFailure` state. The `onError` handler is what stops them becoming fatal.

#7264 is open and covers a complementary cancel path (browser dismissal, kept working under R8 in release builds). No file overlap with this change.

Fixes #7077
