### PR TITLE
fix(auth): Handle worker streams which close without a response

### DIFF
--- a/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/sign_in_state_machine.dart
+++ b/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/sign_in_state_machine.dart
@@ -136,11 +136,32 @@ final class SignInStateMachine
         return worker;
       });
 
+  /// Awaits [response] from the worker named [workerName], surfacing a failed
+  /// worker as an [AuthException].
+  Future<R> _workerResponse<R>(
+    String workerName,
+    Future<R> Function() response,
+  ) async {
+    try {
+      return await response();
+    } on Object catch (e, st) {
+      Error.throwWithStackTrace(
+        UnknownException(
+          'Could not get a response from the $workerName worker',
+          underlyingException: e,
+        ),
+        st,
+      );
+    }
+  }
+
   /// Creates the initial SRP public/private values used in SRP handshakes.
   Future<SrpInitResult> _initSrp() async {
     final worker = await initWorker;
-    worker.add(SrpInitMessage());
-    return worker.stream.first;
+    return _workerResponse(worker.name, () {
+      worker.add(SrpInitMessage());
+      return worker.nextResponse();
+    });
   }
 
   /// The SRP password verifier worker.
@@ -441,8 +462,10 @@ final class SignInStateMachine
             ..password = password,
         );
     });
-    worker.sink.add(workerMessage);
-    return worker.stream.first;
+    return _workerResponse(worker.name, () {
+      worker.sink.add(workerMessage);
+      return worker.nextResponse();
+    });
   }
 
   /// Creates the device SRP auth request to initiate the device SRP flow.
@@ -481,8 +504,10 @@ final class SignInStateMachine
         ..clientSecret = _authOutputs.appClientSecret
         ..challengeParameters = BuiltMap(_publicChallengeParameters);
     });
-    worker.sink.add(workerMessage);
-    return worker.stream.first;
+    return _workerResponse(worker.name, () {
+      worker.sink.add(workerMessage);
+      return worker.nextResponse();
+    });
   }
 
   /// Creates the response object for an SMS MFA challenge.
@@ -1117,14 +1142,16 @@ final class SignInStateMachine
     NewDeviceMetadataType newDeviceMetadata,
   ) async {
     final worker = await confirmDeviceWorker;
-    worker.add(
-      ConfirmDeviceMessage(
-        (b) => b
-          ..accessToken = accessToken
-          ..newDeviceMetadata.replace(newDeviceMetadata),
-      ),
-    );
-    final workerResult = await worker.stream.first;
+    final workerResult = await _workerResponse(worker.name, () {
+      worker.add(
+        ConfirmDeviceMessage(
+          (b) => b
+            ..accessToken = accessToken
+            ..newDeviceMetadata.replace(newDeviceMetadata),
+        ),
+      );
+      return worker.nextResponse();
+    });
     final response = await cognitoIdentityProvider
         .confirmDevice(workerResult.request)
         .result;

--- a/packages/auth/amplify_auth_cognito_test/test/state/sign_in_state_machine_test.dart
+++ b/packages/auth/amplify_auth_cognito_test/test/state/sign_in_state_machine_test.dart
@@ -1,9 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import 'dart:async';
+
 import 'package:amplify_auth_cognito_dart/amplify_auth_cognito_dart.dart';
 import 'package:amplify_auth_cognito_dart/src/credentials/device_metadata_repository.dart';
 import 'package:amplify_auth_cognito_dart/src/flows/constants.dart';
+import 'package:amplify_auth_cognito_dart/src/flows/device/confirm_device_worker.dart';
 import 'package:amplify_auth_cognito_dart/src/model/cognito_device_secrets.dart';
 import 'package:amplify_auth_cognito_dart/src/model/sign_in_parameters.dart';
 import 'package:amplify_auth_cognito_dart/src/sdk/cognito_identity_provider.dart'
@@ -233,6 +236,98 @@ void main() {
               (state) => state.exception,
               'exception',
               isA<cognito_idp.InvalidParameterException>(),
+            ),
+          ),
+        );
+      });
+
+      test('should fail with an AuthException when the confirm device worker '
+          'does not respond', () async {
+        final mockClient = MockCognitoIdentityProviderClient(
+          initiateAuth: expectAsync1((_) async {
+            return cognito_idp.InitiateAuthResponse(
+              authenticationResult: cognito_idp.AuthenticationResultType(
+                accessToken: accessToken.raw,
+                refreshToken: refreshToken,
+                idToken: idToken.raw,
+                newDeviceMetadata: cognito_idp.NewDeviceMetadataType(
+                  deviceKey: deviceKey,
+                  deviceGroupKey: deviceGroupKey,
+                ),
+              ),
+            );
+          }),
+        );
+        stateMachine
+          ..addInstance<cognito_idp.CognitoIdentityProviderClient>(mockClient)
+          ..addInstance<ConfirmDeviceWorker>(
+            _UnresponsiveConfirmDeviceWorker(),
+          );
+
+        await expectLater(
+          stateMachine
+              .accept(
+                SignInEvent.initiate(
+                  parameters: SignInParameters(
+                    (b) => b
+                      ..username = srpUsername
+                      ..password = srpPassword,
+                  ),
+                ),
+              )
+              .completed,
+          completion(
+            isA<SignInFailure>().having(
+              (state) => state.exception,
+              'exception',
+              allOf(isA<AuthException>(), isNot(isA<StateError>())),
+            ),
+          ),
+        );
+      });
+
+      test('should fail with an AuthException when the confirm device worker '
+          'reports an Error', () async {
+        final mockClient = MockCognitoIdentityProviderClient(
+          initiateAuth: expectAsync1((_) async {
+            return cognito_idp.InitiateAuthResponse(
+              authenticationResult: cognito_idp.AuthenticationResultType(
+                accessToken: accessToken.raw,
+                refreshToken: refreshToken,
+                idToken: idToken.raw,
+                newDeviceMetadata: cognito_idp.NewDeviceMetadataType(
+                  deviceKey: deviceKey,
+                  deviceGroupKey: deviceGroupKey,
+                ),
+              ),
+            );
+          }),
+        );
+        stateMachine
+          ..addInstance<cognito_idp.CognitoIdentityProviderClient>(mockClient)
+          ..addInstance<ConfirmDeviceWorker>(
+            _UnresponsiveConfirmDeviceWorker(
+              error: StateError('worker crashed'),
+            ),
+          );
+
+        await expectLater(
+          stateMachine
+              .accept(
+                SignInEvent.initiate(
+                  parameters: SignInParameters(
+                    (b) => b
+                      ..username = srpUsername
+                      ..password = srpPassword,
+                  ),
+                ),
+              )
+              .completed,
+          completion(
+            isA<SignInFailure>().having(
+              (state) => state.exception,
+              'exception',
+              allOf(isA<AuthException>(), isNot(isA<StateError>())),
             ),
           ),
         );
@@ -638,4 +733,32 @@ class _SignInException implements Exception {
 
 class _ConfirmSignInException implements Exception {
   const _ConfirmSignInException();
+}
+
+class _UnresponsiveConfirmDeviceWorker extends ConfirmDeviceWorker {
+  _UnresponsiveConfirmDeviceWorker({Object? error}) {
+    // ignore: close_sinks
+    final requests = StreamController<ConfirmDeviceMessage>.broadcast();
+    sink = requests.sink;
+    if (error != null) {
+      requests.stream.first.then((_) => completeError(error));
+    }
+    // Close the response stream once the request is sent, so the worker closes
+    // without responding.
+    stream = requests.stream
+        .take(1)
+        .asyncExpand((_) => const Stream<ConfirmDeviceResponse>.empty());
+  }
+
+  @override
+  String get name => 'ConfirmDeviceWorker';
+
+  @override
+  String get jsEntrypoint => 'unused.js';
+
+  @override
+  Future<ConfirmDeviceResponse?> run(
+    Stream<ConfirmDeviceMessage> listen,
+    StreamSink<ConfirmDeviceResponse> respond,
+  ) async => null;
 }

--- a/packages/worker_bee/worker_bee/lib/src/common.dart
+++ b/packages/worker_bee/worker_bee/lib/src/common.dart
@@ -207,6 +207,23 @@ abstract class WorkerBeeCommon<Request extends Object, Response>
   /// The stream of responses.
   Stream<Response> get stream => _streamController.stream;
 
+  /// Awaits the next response, throwing a [WorkerBeeException] if the
+  /// worker's stream closes first.
+  Future<Response> nextResponse() async {
+    await for (final response in stream) {
+      return response;
+    }
+
+    // Prefer the worker's own error over a generic "No element".
+    if (isCompleted) {
+      final result = await this.result;
+      if (result.asError case final error?) {
+        Error.throwWithStackTrace(error.error, error.stackTrace);
+      }
+    }
+    throw WorkerBeeExceptionImpl('The $name worker closed before responding');
+  }
+
   @protected
   set stream(Stream<Response> stream) {
     _streamController

--- a/packages/worker_bee/worker_bee/test/next_response_test.dart
+++ b/packages/worker_bee/worker_bee/test/next_response_test.dart
@@ -1,0 +1,94 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import 'dart:async';
+
+import 'package:test/test.dart';
+import 'package:worker_bee/src/common.dart';
+import 'package:worker_bee/src/exception/worker_bee_exception.dart';
+
+class _TestWorker extends WorkerBeeCommon<String, String> {
+  // ignore: close_sinks
+  final StreamController<String> source = StreamController<String>();
+
+  void attach() => stream = source.stream;
+
+  void failWith(Object error) => completeError(error);
+
+  @override
+  String get name => 'TestWorker';
+
+  @override
+  String? get workerEntrypointOverride => null;
+
+  @override
+  Future<String?> run(
+    Stream<String> listen,
+    StreamSink<String> respond,
+  ) async => null;
+
+  @override
+  Future<void> spawn({String? jsEntrypoint}) async {}
+}
+
+void main() {
+  group('WorkerBeeCommon.nextResponse', () {
+    test('returns the next response', () async {
+      final worker = _TestWorker()..attach();
+      final next = worker.nextResponse();
+      worker.source.add('response');
+      await expectLater(next, completion('response'));
+    });
+
+    test('throws an Exception when the stream closes without a '
+        'response', () async {
+      final worker = _TestWorker()..attach();
+      final next = worker.nextResponse();
+      await worker.source.close();
+
+      await expectLater(
+        next,
+        throwsA(
+          allOf(
+            isA<Exception>(),
+            isA<WorkerBeeException>(),
+            isNot(isA<StateError>()),
+          ),
+        ),
+      );
+    });
+
+    test('throws the exception reported by the worker', () async {
+      final worker = _TestWorker()..attach();
+      final next = worker.nextResponse();
+
+      worker.failWith(WorkerBeeExceptionImpl('Worker quit unexpectedly'));
+      await worker.source.close();
+
+      await expectLater(
+        next,
+        throwsA(
+          allOf(
+            isA<Exception>(),
+            isNot(isA<StateError>()),
+            isA<WorkerBeeException>().having(
+              (e) => e.toString(),
+              'message',
+              contains('Worker quit unexpectedly'),
+            ),
+          ),
+        ),
+      );
+    });
+
+    test('rethrows an Error reported by the worker', () async {
+      final worker = _TestWorker()..attach();
+      final next = worker.nextResponse();
+
+      worker.failWith(StateError('worker crashed'));
+      await worker.source.close();
+
+      await expectLater(next, throwsA(isA<StateError>()));
+    });
+  });
+}


### PR DESCRIPTION
## Description

During sign-in, `SignInStateMachine` awaited `worker.stream.first` for each worker's response. If that stream closes without emitting, `.first` throws `StateError` ("Bad state: No element"), which is an `Error` rather than an `Exception`, so `resolveError` let it escape to the app's root zone uncaught.

The fix adds `WorkerBeeCommon.nextResponse`, which surfaces the worker's real error instead, wrapped as an `UnknownException` at all four sign-in call sites so callers get an `AuthException`. The request send sits inside the guard too, so a send to an already-closed worker ("Cannot add event after closing") is wrapped rather than thrown raw.

All workers on the sign-in path were tested. `ConfirmDeviceWorker` reproduced the reported behavior most closely, since it runs after Cognito has returned tokens, so the user ends up signed in while the error still surfaces.

## Testing

- Regression tests: signing in with a `ConfirmDeviceWorker` which never responds, and one which reports an `Error`, both now fail with an `AuthException`. Without the change both fail with `Bad state: No element`.
- `worker_bee` unit tests for `nextResponse` cover a normal response, an empty close, a worker-reported exception, and a worker-reported `Error`.
- `worker_bee` suite green on VM and Chrome; `amplify_auth_cognito_test` and `amplify_secure_storage_test` green.
- `dart analyze --fatal-infos --fatal-warnings`, `dart format` and `dart fix` clean.
- Verified e2e on Flutter web against live Cognito: the uncaught `Bad state: No element` no longer occurs, `signIn` throws a catchable `AuthException`, and the session remains valid.

Refs #7355
