### PR TITLE
chore(version): Version bump

### DIFF
--- a/packages/amplify_datastore/CHANGELOG.md
+++ b/packages/amplify_datastore/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.15.1
+
+- Minor bug fixes and improvements
+
 ## 2.15.0
 
 ### Features

--- a/packages/amplify_datastore/pubspec.yaml
+++ b/packages/amplify_datastore/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_datastore
 description: The Amplify Flutter DataStore category plugin, providing a queryable, on-device data store.
-version: 2.15.0
+version: 2.15.1
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/amplify_datastore
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues

--- a/packages/api/amplify_api/CHANGELOG.md
+++ b/packages/api/amplify_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.15.1
+
+- Minor bug fixes and improvements
+
 ## 2.15.0
 
 ### Features

--- a/packages/api/amplify_api/pubspec.yaml
+++ b/packages/api/amplify_api/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_api
 description: The Amplify Flutter API category plugin, supporting GraphQL and REST operations.
-version: 2.15.0
+version: 2.15.1
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/api/amplify_api
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues

--- a/packages/api/amplify_api_dart/CHANGELOG.md
+++ b/packages/api/amplify_api_dart/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.23
+
+### Fixes
+- fix(api): Don't block subscription events during WebSocket reconnect ([#7282](https://github.com/aws-amplify/amplify-flutter/pull/7282))
+
 ## 0.5.22
 
 - Minor bug fixes and improvements

--- a/packages/api/amplify_api_dart/pubspec.yaml
+++ b/packages/api/amplify_api_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_api_dart
 description: The Amplify API category plugin in Dart-only, supporting GraphQL and REST operations.
-version: 0.5.22
+version: 0.5.23
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/api/amplify_api_dart
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues

--- a/packages/authenticator/amplify_authenticator/CHANGELOG.md
+++ b/packages/authenticator/amplify_authenticator/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.7.1
+
+### Fixes
+- fix(api): Don't block subscription events during WebSocket reconnect ([#7282](https://github.com/aws-amplify/amplify-flutter/pull/7282))
+- fix(authenticator): Add accessible names for password toggle and form errors ([#7254](https://github.com/aws-amplify/amplify-flutter/pull/7254))
+- fix(authenticator): Make Verify User Skip button visible in dark mode ([#7275](https://github.com/aws-amplify/amplify-flutter/pull/7275))
+- fix(authenticator): enforce required validation for empty phone number field ([#7296](https://github.com/aws-amplify/amplify-flutter/pull/7296))
+
 ## 2.7.0
 
 ### Features

--- a/packages/authenticator/amplify_authenticator/CHANGELOG.md
+++ b/packages/authenticator/amplify_authenticator/CHANGELOG.md
@@ -4,7 +4,7 @@
 - fix(api): Don't block subscription events during WebSocket reconnect ([#7282](https://github.com/aws-amplify/amplify-flutter/pull/7282))
 - fix(authenticator): Add accessible names for password toggle and form errors ([#7254](https://github.com/aws-amplify/amplify-flutter/pull/7254))
 - fix(authenticator): Make Verify User Skip button visible in dark mode ([#7275](https://github.com/aws-amplify/amplify-flutter/pull/7275))
-- fix(authenticator): enforce required validation for empty phone number field ([#7296](https://github.com/aws-amplify/amplify-flutter/pull/7296))
+- fix(authenticator): Enforce required validation for empty phone number field ([#7296](https://github.com/aws-amplify/amplify-flutter/pull/7296))
 
 ## 2.7.0
 

--- a/packages/authenticator/amplify_authenticator/lib/src/version.dart
+++ b/packages/authenticator/amplify_authenticator/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '2.7.0';
+const packageVersion = '2.7.1';

--- a/packages/authenticator/amplify_authenticator/pubspec.yaml
+++ b/packages/authenticator/amplify_authenticator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_authenticator
 description: A prebuilt Sign In and Sign Up experience for the Amplify Auth category
-version: 2.7.0
+version: 2.7.1
 homepage: https://ui.docs.amplify.aws/flutter/connected-components/authenticator
 repository: https://github.com/aws-amplify/amplify-flutter/tree/main/packages/authenticator/amplify_authenticator
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues

--- a/packages/notifications/push/amplify_push_notifications/CHANGELOG.md
+++ b/packages/notifications/push/amplify_push_notifications/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.15.1
+
+- Minor bug fixes and improvements
+
 ## 2.15.0
 
 ### Features

--- a/packages/notifications/push/amplify_push_notifications/pubspec.yaml
+++ b/packages/notifications/push/amplify_push_notifications/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplify_push_notifications
 description: The Amplify Flutter Push Notifications package implementing features agnostic of an AWS Service such as Pinpoint.
-version: 2.15.0
+version: 2.15.1
 homepage: https://docs.amplify.aws/lib/q/platform/flutter/
 issue_tracker: https://github.com/aws-amplify/amplify-flutter/issues
 


### PR DESCRIPTION
Automated version bump created by the **Version Bump** workflow.

**Branch:** `chore/release/version-bump/2026-09-03`
**Triggered by:** @cadivus

### Affected Packages

- `amplify_datastore`: `2.15.0` → `2.15.1`
- `amplify_api`: `2.15.0` → `2.15.1`
- `amplify_api_dart`: `0.5.22` → `0.5.23`
- `amplify_authenticator`: `2.7.0` → `2.7.1`
- `amplify_push_notifications`: `2.15.0` → `2.15.1`
