### PR TITLE
ci: Add missing checkout to tag release

### DIFF
--- a/.github/workflows/publish-tag.yaml
+++ b/.github/workflows/publish-tag.yaml
@@ -152,6 +152,13 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
+      # gh release create --verify-tag runs git, which needs a checkout.
+      - name: Git Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
       # Runs even when publishing was a no-op, so a re-run can still create a
       # release which is missing.
       - name: Create GitHub release


### PR DESCRIPTION
The git repo needs to be cloned again. Extracting the release notes before getting the PUB_DEV token is more stable.