### PR TITLE
fix(storage): Dedupe AbortMultipartUpload on concurrent part failures

### DIFF
--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_upload_task.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_upload_task.dart
@@ -762,6 +762,11 @@ class S3UploadTask {
       return;
     }
 
+    // set failure before the await so the guard dedupes concurrent aborts
+    if (!isCancel) {
+      _state = StorageTransferState.failure;
+    }
+
     final request = s3.AbortMultipartUploadRequest.build((builder) {
       builder
         ..bucket = _bucket

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_upload_task.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/service/task/s3_upload_task.dart
@@ -774,7 +774,11 @@ class S3UploadTask {
         ..uploadId = _multipartUploadId;
     });
 
-    await _s3Client.abortMultipartUpload(request).result;
+    try {
+      await _s3Client.abortMultipartUpload(request).result;
+    } on Exception catch (e) {
+      _logger.error('Failed to abort multipart upload', e);
+    }
 
     if (isCancel) {
       _uploadCompleter.completeError(error);

--- a/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/transfer/database/tables.drift.dart
+++ b/packages/storage/amplify_storage_s3_dart/lib/src/storage_s3_service/transfer/database/tables.drift.dart
@@ -203,7 +203,18 @@ class $$TransferRecordsTableTableManager
                 awsRegion: awsRegion,
               ),
           withReferenceMapper: (p0) => p0
-              .map((e) => (e.readTable(table), i0.BaseReferences(db, table, e)))
+              .map(
+                (e) => (
+                  e.readTable<i1.$TransferRecordsTable, i1.TransferRecord>(
+                    table,
+                  ),
+                  i0.BaseReferences<
+                    i0.GeneratedDatabase,
+                    i1.$TransferRecordsTable,
+                    i1.TransferRecord
+                  >(db, table, e),
+                ),
+              )
               .toList(),
           prefetchHooksCallback: null,
         ),

--- a/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/task/s3_upload_task_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/task/s3_upload_task_test.dart
@@ -1886,6 +1886,82 @@ void main() {
         },
       );
 
+      test(
+        'should send only one AbortMultipartUpload request when multiple parts '
+        'fail concurrently',
+        () async {
+          // A >5MB AWSFile uploads its parts in parallel, so multiple
+          // parts can fail while the abort triggered by the first failure is
+          // still in flight. Use a dedicated client so the abort call count is
+          // isolated from the suite-level mock shared with other tests.
+          final localS3Client = MockS3Client();
+          final testFile = AWSFile.fromData(testBytes);
+          const testMultipartUploadId = 'some-upload-id';
+
+          final createMultipartUploadSmithyOperation =
+              MockSmithyOperation<s3.CreateMultipartUploadOutput>();
+          when(() => createMultipartUploadSmithyOperation.result).thenAnswer(
+            (_) async =>
+                s3.CreateMultipartUploadOutput(uploadId: testMultipartUploadId),
+          );
+          when(
+            () => localS3Client.createMultipartUpload(any()),
+          ).thenAnswer((_) => createMultipartUploadSmithyOperation);
+
+          when(
+            () => transferDatabase.insertTransferRecord(any()),
+          ).thenAnswer((_) async => '1');
+
+          // Every part upload fails.
+          const testException = smithy.UnknownSmithyHttpException(
+            statusCode: 403,
+            body: 'Access denied!',
+          );
+          when(
+            () => localS3Client.uploadPart(
+              any(),
+              s3ClientConfig: any(named: 's3ClientConfig'),
+            ),
+          ).thenThrow(testException);
+
+          // Delay the abort response so all concurrent part failures reach the
+          // dedupe guard while the first abort is still awaiting.
+          final abortMultipartUploadSmithyOperation =
+              MockSmithyOperation<s3.AbortMultipartUploadOutput>();
+          when(() => abortMultipartUploadSmithyOperation.result).thenAnswer((
+            _,
+          ) async {
+            await Future<void>.delayed(const Duration(milliseconds: 50));
+            return s3.AbortMultipartUploadOutput();
+          });
+          when(
+            () => localS3Client.abortMultipartUpload(any()),
+          ).thenAnswer((_) => abortMultipartUploadSmithyOperation);
+
+          final uploadTask = S3UploadTask.fromAWSFile(
+            testFile,
+            s3Client: localS3Client,
+            s3ClientConfig: defaultS3ClientConfig,
+            pathResolver: pathResolver,
+            bucket: testBucket,
+            awsRegion: testRegion,
+            path: const StoragePath.fromString(testKey),
+            options: testUploadDataOptions,
+            logger: logger,
+            transferDatabase: transferDatabase,
+          );
+
+          unawaited(uploadTask.start());
+
+          await expectLater(
+            uploadTask.result,
+            throwsA(isA<StorageException>()),
+          );
+
+          verify(() => localS3Client.abortMultipartUpload(any())).called(1);
+        },
+      );
+
       group('Control APIs', () {
         final testLocalFile = AWSFile.fromData(testBytes);
         final testUploadPartOutput1 = s3.UploadPartOutput(eTag: 'eTag-part-1');

--- a/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/task/s3_upload_task_test.dart
+++ b/packages/storage/amplify_storage_s3_dart/test/storage_s3_service/task/s3_upload_task_test.dart
@@ -1912,7 +1912,6 @@ void main() {
             () => transferDatabase.insertTransferRecord(any()),
           ).thenAnswer((_) async => '1');
 
-          // Every part upload fails.
           const testException = smithy.UnknownSmithyHttpException(
             statusCode: 403,
             body: 'Access denied!',
@@ -1961,6 +1960,63 @@ void main() {
           verify(() => localS3Client.abortMultipartUpload(any())).called(1);
         },
       );
+
+      test('should still fail with the original error when the '
+          'AbortMultipartUpload request itself fails', () async {
+        final uploadTask = S3UploadTask.fromAWSFile(
+          testLocalFile,
+          s3Client: s3Client,
+          s3ClientConfig: defaultS3ClientConfig,
+          pathResolver: pathResolver,
+          bucket: testBucket,
+          awsRegion: testRegion,
+          path: const StoragePath.fromString(testKey),
+          options: testUploadDataOptions,
+          logger: logger,
+          transferDatabase: transferDatabase,
+        );
+        const testMultipartUploadId = 'some-upload-id';
+
+        final testCreateMultipartUploadOutput = s3.CreateMultipartUploadOutput(
+          uploadId: testMultipartUploadId,
+        );
+        final createMultipartUploadSmithyOperation =
+            MockSmithyOperation<s3.CreateMultipartUploadOutput>();
+        when(
+          () => createMultipartUploadSmithyOperation.result,
+        ).thenAnswer((_) async => testCreateMultipartUploadOutput);
+        when(
+          () => s3Client.createMultipartUpload(any()),
+        ).thenAnswer((_) => createMultipartUploadSmithyOperation);
+
+        when(
+          () => transferDatabase.insertTransferRecord(any()),
+        ).thenAnswer((_) async => '1');
+
+        const testException = smithy.UnknownSmithyHttpException(
+          statusCode: 403,
+          body: 'Access denied!',
+        );
+        when(
+          () => s3Client.uploadPart(
+            any(),
+            s3ClientConfig: any(named: 's3ClientConfig'),
+          ),
+        ).thenThrow(testException);
+
+        unawaited(uploadTask.start());
+
+        final abortMultipartUploadSmithyOperation =
+            MockSmithyOperation<s3.AbortMultipartUploadOutput>();
+        when(
+          () => abortMultipartUploadSmithyOperation.result,
+        ).thenThrow(Exception('abort failed'));
+        when(
+          () => s3Client.abortMultipartUpload(any()),
+        ).thenAnswer((_) => abortMultipartUploadSmithyOperation);
+
+        await expectLater(uploadTask.result, throwsA(isA<StorageException>()));
+      });
 
       group('Control APIs', () {
         final testLocalFile = AWSFile.fromData(testBytes);


### PR DESCRIPTION
## Description
Follow-up to the review comment on #7354.

When several parts of a multipart upload fail at the same time, each failure tries to abort the upload. A guard is supposed to send `AbortMultipartUpload` only once by checking whether the transfer state is already `failure`, but the state wasn't set to `failure` until after the abort request's `await` completed, so all the concurrent failures passed the guard during that await window and each sent its own abort (N failed parts to N aborts).

This sets the state to `failure` before the await, so later concurrent failures hit the guard and return early.

## Tests
- Regression test drives concurrent part failures and asserts a single `AbortMultipartUpload`; fails without the fix (3 aborts), passes with it (1 abort).
- Full `amplify_storage_s3_dart` unit suite green; `dart analyze` and `dart format` clean (Dart 3.11 and 3.12).
- No live e2e: the abort count isn't observable from the client and concurrent part failures can't be forced against real S3, so the deterministic unit repro is the proof.
